### PR TITLE
fix: introduce ConnectionState::Cancelled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,6 +516,7 @@ pub enum ConnectionState {
     InProgress,
     Succeeded,
     Failed,
+    Cancelled,
 }
 
 #[derive(Debug, Clone)]
@@ -887,11 +888,20 @@ impl HappyEyeballs {
             return;
         };
 
-        debug_assert_eq!(
-            attempt.state,
-            ConnectionState::InProgress,
-            "got connection result but attempt is not in progress: {attempt:?}"
-        );
+        match attempt.state {
+            ConnectionState::InProgress => {}
+            ConnectionState::Cancelled => {
+                log::debug!("ignoring connection result for cancelled attempt {id:?}: {result:?}");
+                return;
+            }
+            ConnectionState::Succeeded | ConnectionState::Failed => {
+                debug_assert!(
+                    false,
+                    "got connection result but attempt is in unexpected state: {attempt:?}"
+                );
+                return;
+            }
+        }
 
         match result {
             Ok(()) => {
@@ -923,7 +933,7 @@ impl HappyEyeballs {
             .find(|a| a.state == ConnectionState::InProgress)
         {
             let id = attempt.id;
-            attempt.state = ConnectionState::Failed;
+            attempt.state = ConnectionState::Cancelled;
             return Some(Output::CancelConnection { id });
         }
 

--- a/tests/connection_attempts.rs
+++ b/tests/connection_attempts.rs
@@ -255,6 +255,59 @@ fn succeeded_keeps_emitting_succeeded() {
 }
 
 #[test]
+fn cancelled_connection_result_ignored() {
+    let (mut now, mut he) = setup();
+
+    he.expect(
+        vec![
+            (None, Some(out_send_dns_https(Id::from(0)))),
+            (None, Some(out_send_dns_aaaa(Id::from(1)))),
+            (None, Some(out_send_dns_a(Id::from(2)))),
+            (
+                Some(in_dns_https_positive_no_alpn(Id::from(0))),
+                Some(out_resolution_delay()),
+            ),
+            (
+                Some(in_dns_aaaa_positive(Id::from(1))),
+                Some(out_attempt_v6_h1_h2(Id::from(3))),
+            ),
+            (
+                Some(in_dns_a_positive(Id::from(2))),
+                Some(out_connection_attempt_delay()),
+            ),
+        ],
+        now,
+    );
+
+    now += CONNECTION_ATTEMPT_DELAY;
+
+    // Start second connection attempt.
+    he.expect(vec![(None, Some(out_attempt_v4_h1_h2(Id::from(4))))], now);
+
+    // First connection succeeds, triggering cancellation of the second.
+    he.expect(
+        vec![
+            (
+                Some(in_connection_result_positive(Id::from(3))),
+                Some(Output::CancelConnection { id: Id::from(4) }),
+            ),
+            (None, Some(Output::Succeeded)),
+        ],
+        now,
+    );
+
+    // User reports an error for the already-cancelled connection.
+    // This must not panic.
+    he.expect(
+        vec![(
+            Some(in_connection_result_negative(Id::from(4))),
+            Some(Output::Succeeded),
+        )],
+        now,
+    );
+}
+
+#[test]
 fn all_connections_failed() {
     let (now, mut he) = setup();
 


### PR DESCRIPTION
Previously, when receiving a connection result for a cancelled connection, the state machine would panic. This commit introduces a new state, i.e. ConnectionState::Cancelled, ignoring connection results if applicable.