### PR TITLE
chore: use http version instead of protocol

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ impl DnsResult {
     fn flatten_into_endpoints(
         &self,
         port: u16,
-        protocols: &HashSet<ConnectionAttemptHttpVersions>,
+        http_versions: &HashSet<ConnectionAttemptHttpVersions>,
     ) -> Vec<Endpoint> {
         match self {
             DnsResult::Https(_) => unreachable!(),
@@ -126,9 +126,9 @@ impl DnsResult {
                 .into_iter()
                 .flat_map(|addrs| {
                     addrs.iter().cloned().flat_map(|ip| {
-                        protocols.iter().map(move |p| Endpoint {
+                        http_versions.iter().map(move |v| Endpoint {
                             address: SocketAddr::new(IpAddr::V6(ip), port),
-                            protocol: *p,
+                            http_version: *v,
                             ech_config: None,
                         })
                     })
@@ -141,9 +141,9 @@ impl DnsResult {
                 .into_iter()
                 .flat_map(|addrs| {
                     addrs.iter().cloned().flat_map(|ip| {
-                        protocols.iter().map(move |p| Endpoint {
+                        http_versions.iter().map(move |v| Endpoint {
                             address: SocketAddr::new(IpAddr::V4(ip), port),
-                            protocol: *p,
+                            http_version: *v,
                             ech_config: None,
                         })
                     })
@@ -229,7 +229,7 @@ pub enum DnsRecordType {
 pub struct ServiceInfo {
     pub priority: u16,
     pub target_name: TargetName,
-    pub alpn_protocols: HashSet<HttpVersion>,
+    pub alpn_http_versions: HashSet<HttpVersion>,
     pub ech_config: Option<Vec<u8>>,
     pub ipv4_hints: Vec<Ipv4Addr>,
     pub ipv6_hints: Vec<Ipv6Addr>,
@@ -243,8 +243,8 @@ impl Debug for ServiceInfo {
         debug_struct.field("priority", &self.priority);
         debug_struct.field("target", &self.target_name);
 
-        if !self.alpn_protocols.is_empty() {
-            debug_struct.field("alpn", &self.alpn_protocols);
+        if !self.alpn_http_versions.is_empty() {
+            debug_struct.field("alpn", &self.alpn_http_versions);
         }
 
         if self.ech_config.is_some() {
@@ -269,7 +269,7 @@ impl ServiceInfo {
         port: u16,
         ipv4_addrs: &[Ipv4Addr],
         ipv6_addrs: &[Ipv6Addr],
-        protocols: &HashSet<ConnectionAttemptHttpVersions>,
+        http_versions: &HashSet<ConnectionAttemptHttpVersions>,
     ) -> Vec<Endpoint> {
         let port = self.port.unwrap_or(port);
 
@@ -291,9 +291,9 @@ impl ServiceInfo {
             &[]
         };
 
-        let hint_protocols: HashSet<ConnectionAttemptHttpVersions> =
-            ConnectionAttemptHttpVersions::from_protocols(&self.alpn_protocols)
-                .intersection(protocols)
+        let hint_http_versions: HashSet<ConnectionAttemptHttpVersions> =
+            ConnectionAttemptHttpVersions::from_alpn(&self.alpn_http_versions)
+                .intersection(http_versions)
                 .cloned()
                 .collect();
 
@@ -305,11 +305,13 @@ impl ServiceInfo {
             .flat_map(|ip| {
                 // TODO: way around allocation?
                 let ech_config = self.ech_config.clone();
-                hint_protocols.iter().map(move |&protocol| Endpoint {
-                    address: SocketAddr::new(ip, port),
-                    protocol,
-                    ech_config: ech_config.clone(),
-                })
+                hint_http_versions
+                    .iter()
+                    .map(move |&http_version| Endpoint {
+                        address: SocketAddr::new(ip, port),
+                        http_version,
+                        ech_config: ech_config.clone(),
+                    })
             });
 
         let addrs = ipv6_addrs
@@ -320,9 +322,9 @@ impl ServiceInfo {
             .flat_map(|ip| {
                 // TODO: way around allocation?
                 let ech_config = self.ech_config.clone();
-                protocols.iter().map(move |p| Endpoint {
+                http_versions.iter().map(move |v| Endpoint {
                     address: SocketAddr::new(ip, port),
-                    protocol: *p,
+                    http_version: *v,
                     ech_config: ech_config.clone(),
                 })
             });
@@ -338,7 +340,7 @@ pub enum HttpVersion {
     H1,
 }
 
-/// Possible connection attempt protocol combinations.
+/// Possible connection attempt HTTP version combinations.
 ///
 /// While on a QUIC connection attempts one can only use HTTP/3, on a TCP
 /// connection attempt one might either negotiate HTTP/2 or HTTP/1.1 via TLS
@@ -353,16 +355,16 @@ pub enum ConnectionAttemptHttpVersions {
 
 impl ConnectionAttemptHttpVersions {
     /// [`HttpVersion::H2`] and [`HttpVersion::H1`] into [`ConnectionAttemptHttpVersions::H2OrH1`].
-    fn from_protocols(protocols: &HashSet<HttpVersion>) -> HashSet<ConnectionAttemptHttpVersions> {
+    fn from_alpn(http_versions: &HashSet<HttpVersion>) -> HashSet<ConnectionAttemptHttpVersions> {
         let mut combinations = HashSet::new();
-        if protocols.contains(&HttpVersion::H3) {
+        if http_versions.contains(&HttpVersion::H3) {
             combinations.insert(ConnectionAttemptHttpVersions::H3);
         }
-        if protocols.contains(&HttpVersion::H2) && protocols.contains(&HttpVersion::H1) {
+        if http_versions.contains(&HttpVersion::H2) && http_versions.contains(&HttpVersion::H1) {
             combinations.insert(ConnectionAttemptHttpVersions::H2OrH1);
-        } else if protocols.contains(&HttpVersion::H2) {
+        } else if http_versions.contains(&HttpVersion::H2) {
             combinations.insert(ConnectionAttemptHttpVersions::H2);
-        } else if protocols.contains(&HttpVersion::H1) {
+        } else if http_versions.contains(&HttpVersion::H1) {
             combinations.insert(ConnectionAttemptHttpVersions::H1);
         }
         combinations
@@ -456,7 +458,7 @@ pub enum IpPreference {
 pub struct AltSvc {
     pub host: Option<String>,
     pub port: Option<u16>,
-    pub protocol: HttpVersion,
+    pub http_version: HttpVersion,
 }
 
 // TODO: Should we make HappyEyeballs proxy aware? E.g. should it know that the
@@ -533,18 +535,18 @@ impl ConnectionAttempt {
     }
 }
 
-/// All information (IP, protocol, ...) needed to attempt a connection to a specific endpoint.
+/// All information (IP, HTTP version, ...) needed to attempt a connection to a specific endpoint.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Endpoint {
     pub address: SocketAddr,
-    pub protocol: ConnectionAttemptHttpVersions,
+    pub http_version: ConnectionAttemptHttpVersions,
     pub ech_config: Option<Vec<u8>>,
 }
 
 impl Endpoint {
     fn sort_with_config(&self, other: &Endpoint, network_config: &NetworkConfig) -> Ordering {
-        if self.protocol != other.protocol {
-            return self.protocol.cmp(&other.protocol);
+        if self.http_version != other.http_version {
+            return self.http_version.cmp(&other.http_version);
         }
 
         let order = self
@@ -988,18 +990,18 @@ impl HappyEyeballs {
     fn next_endpoint_to_attempt(&self) -> Option<Endpoint> {
         let origin_domain = match &self.host {
             Host::Ipv4(ipv4_addr) => {
-                let protocols = self.connection_attempt_protocols();
+                let http_versions = self.connection_attempt_http_versions();
                 return Some(Endpoint {
                     address: SocketAddr::new(IpAddr::V4(*ipv4_addr), self.port),
-                    protocol: *protocols.iter().next()?,
+                    http_version: *http_versions.iter().next()?,
                     ech_config: None,
                 });
             }
             Host::Ipv6(ipv6_addr) => {
-                let protocols = self.connection_attempt_protocols();
+                let http_versions = self.connection_attempt_http_versions();
                 return Some(Endpoint {
                     address: SocketAddr::new(IpAddr::V6(*ipv6_addr), self.port),
-                    protocol: *protocols.iter().next()?,
+                    http_version: *http_versions.iter().next()?,
                     ech_config: None,
                 });
             }
@@ -1022,7 +1024,7 @@ impl HappyEyeballs {
         service_infos.sort_by_key(|i| i.priority);
 
         // build a sorted endpoints per ServiceInfo.
-        let protocols = self.connection_attempt_protocols();
+        let http_versions = self.connection_attempt_http_versions();
         let mut endpoints: Vec<Endpoint> = Vec::new();
         for info in &service_infos {
             let ipv4_addrs: Vec<Ipv4Addr> = self
@@ -1054,7 +1056,7 @@ impl HappyEyeballs {
                 .cloned()
                 .collect();
             let mut bucket =
-                info.flatten_into_endpoints(self.port, &ipv4_addrs, &ipv6_addrs, &protocols);
+                info.flatten_into_endpoints(self.port, &ipv4_addrs, &ipv6_addrs, &http_versions);
             bucket.sort_by(|a, b| a.sort_with_config(b, &self.network_config));
             endpoints.extend(bucket);
         }
@@ -1071,7 +1073,7 @@ impl HappyEyeballs {
                 } if target_name.as_str() == origin_domain => Some(r),
                 _ => None,
             })
-            .flat_map(|r| r.flatten_into_endpoints(self.port, &protocols))
+            .flat_map(|r| r.flatten_into_endpoints(self.port, &http_versions))
             .collect();
         bucket.sort_by(|a, b| a.sort_with_config(b, &self.network_config));
         endpoints.extend(bucket);
@@ -1102,49 +1104,53 @@ impl HappyEyeballs {
             .any(|a| a.state == ConnectionState::InProgress)
     }
 
-    fn connection_attempt_protocols(&self) -> HashSet<ConnectionAttemptHttpVersions> {
-        let mut protocols = HashSet::new();
+    fn connection_attempt_http_versions(&self) -> HashSet<ConnectionAttemptHttpVersions> {
+        let mut http_versions = HashSet::new();
 
-        // Add protocols from DNS HTTPS records
-        protocols.extend(
+        // Add HTTP versions from DNS HTTPS records
+        http_versions.extend(
             self.dns_queries
                 .iter()
                 .filter_map(|q| match q {
                     DnsQuery::Completed {
                         response: DnsResult::Https(Ok(infos)),
                         ..
-                    } => Some(infos.iter().flat_map(|i| i.alpn_protocols.iter().cloned())),
+                    } => Some(
+                        infos
+                            .iter()
+                            .flat_map(|i| i.alpn_http_versions.iter().cloned()),
+                    ),
                     _ => None,
                 })
                 .flatten(),
         );
 
-        // If HTTPS DNS records didn't specify any protocols, default to HTTP/2, and HTTP/1.1.
-        if protocols.is_empty() {
-            protocols.insert(HttpVersion::H2);
-            protocols.insert(HttpVersion::H1);
+        // If HTTPS DNS records didn't specify any HTTP versions, default to HTTP/2, and HTTP/1.1.
+        if http_versions.is_empty() {
+            http_versions.insert(HttpVersion::H2);
+            http_versions.insert(HttpVersion::H1);
         }
 
-        // Add protocols from alt-svc
+        // Add HTTP versions from alt-svc
         for alt_svc in &self.network_config.alt_svc {
             debug_assert!(
                 alt_svc.host.is_none() && alt_svc.port.is_none(),
                 "alt-svc with custom host/port not yet supported"
             );
-            protocols.insert(alt_svc.protocol);
+            http_versions.insert(alt_svc.http_version);
         }
 
         if !self.network_config.http_versions.h3 {
-            protocols.remove(&HttpVersion::H3);
+            http_versions.remove(&HttpVersion::H3);
         }
         if !self.network_config.http_versions.h2 {
-            protocols.remove(&HttpVersion::H2);
+            http_versions.remove(&HttpVersion::H2);
         }
         if !self.network_config.http_versions.h1 {
-            protocols.remove(&HttpVersion::H1);
+            http_versions.remove(&HttpVersion::H1);
         }
 
-        ConnectionAttemptHttpVersions::from_protocols(&protocols)
+        ConnectionAttemptHttpVersions::from_alpn(&http_versions)
     }
 
     /// Whether to move on to the connection attempt phase based on the received

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -60,7 +60,7 @@ pub fn in_dns_https_positive(id: Id) -> Input {
         result: DnsResult::Https(Ok(vec![ServiceInfo {
             priority: 1,
             target_name: HOSTNAME.into(),
-            alpn_protocols: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
             ipv6_hints: vec![],
             ipv4_hints: vec![],
             ech_config: None,
@@ -75,7 +75,7 @@ pub fn in_dns_https_positive_no_alpn(id: Id) -> Input {
         result: DnsResult::Https(Ok(vec![ServiceInfo {
             priority: 1,
             target_name: HOSTNAME.into(),
-            alpn_protocols: HashSet::new(),
+            alpn_http_versions: HashSet::new(),
             ipv6_hints: vec![],
             ipv4_hints: vec![],
             ech_config: None,
@@ -90,7 +90,7 @@ pub fn in_dns_https_positive_v6_hints(id: Id) -> Input {
         result: DnsResult::Https(Ok(vec![ServiceInfo {
             priority: 1,
             target_name: HOSTNAME.into(),
-            alpn_protocols: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
             ipv6_hints: vec![V6_ADDR],
             ipv4_hints: vec![],
             ech_config: None,
@@ -105,7 +105,7 @@ pub fn in_dns_https_positive_svc1(id: Id) -> Input {
         result: DnsResult::Https(Ok(vec![ServiceInfo {
             priority: 1,
             target_name: SVC1.into(),
-            alpn_protocols: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
             ipv6_hints: vec![V6_ADDR_2],
             ipv4_hints: vec![],
             ech_config: None,
@@ -197,7 +197,7 @@ pub fn out_attempt_v6_h1_h2(id: Id) -> Output {
         id,
         endpoint: Endpoint {
             address: SocketAddr::new(V6_ADDR.into(), PORT),
-            protocol: ConnectionAttemptHttpVersions::H2OrH1,
+            http_version: ConnectionAttemptHttpVersions::H2OrH1,
             ech_config: None,
         },
     }
@@ -208,7 +208,7 @@ pub fn out_attempt_v6_h2(id: Id) -> Output {
         id,
         endpoint: Endpoint {
             address: SocketAddr::new(V6_ADDR.into(), PORT),
-            protocol: ConnectionAttemptHttpVersions::H2,
+            http_version: ConnectionAttemptHttpVersions::H2,
             ech_config: None,
         },
     }
@@ -219,7 +219,7 @@ pub fn out_attempt_v6_h3(id: Id) -> Output {
         id,
         endpoint: Endpoint {
             address: SocketAddr::new(V6_ADDR.into(), PORT),
-            protocol: ConnectionAttemptHttpVersions::H3,
+            http_version: ConnectionAttemptHttpVersions::H3,
             ech_config: None,
         },
     }
@@ -230,7 +230,7 @@ pub fn out_attempt_v6_h3_custom_port(id: Id) -> Output {
         id,
         endpoint: Endpoint {
             address: SocketAddr::new(V6_ADDR.into(), CUSTOM_PORT),
-            protocol: ConnectionAttemptHttpVersions::H3,
+            http_version: ConnectionAttemptHttpVersions::H3,
             ech_config: None,
         },
     }
@@ -241,7 +241,7 @@ pub fn out_attempt_v4_h1_h2(id: Id) -> Output {
         id,
         endpoint: Endpoint {
             address: SocketAddr::new(V4_ADDR.into(), PORT),
-            protocol: ConnectionAttemptHttpVersions::H2OrH1,
+            http_version: ConnectionAttemptHttpVersions::H2OrH1,
             ech_config: None,
         },
     }
@@ -252,7 +252,7 @@ pub fn out_attempt_v4_h2(id: Id) -> Output {
         id,
         endpoint: Endpoint {
             address: SocketAddr::new(V4_ADDR.into(), PORT),
-            protocol: ConnectionAttemptHttpVersions::H2,
+            http_version: ConnectionAttemptHttpVersions::H2,
             ech_config: None,
         },
     }
@@ -263,7 +263,7 @@ pub fn out_attempt_v4_h3(id: Id) -> Output {
         id,
         endpoint: Endpoint {
             address: SocketAddr::new(V4_ADDR.into(), PORT),
-            protocol: ConnectionAttemptHttpVersions::H3,
+            http_version: ConnectionAttemptHttpVersions::H3,
             ech_config: None,
         },
     }
@@ -274,7 +274,7 @@ pub fn out_attempt_v4_h3_custom_port(id: Id) -> Output {
         id,
         endpoint: Endpoint {
             address: SocketAddr::new(V4_ADDR.into(), CUSTOM_PORT),
-            protocol: ConnectionAttemptHttpVersions::H3,
+            http_version: ConnectionAttemptHttpVersions::H3,
             ech_config: None,
         },
     }
@@ -285,7 +285,7 @@ pub fn out_attempt_v6_h2_custom_port(id: Id) -> Output {
         id,
         endpoint: Endpoint {
             address: SocketAddr::new(V6_ADDR.into(), CUSTOM_PORT),
-            protocol: ConnectionAttemptHttpVersions::H2,
+            http_version: ConnectionAttemptHttpVersions::H2,
             ech_config: None,
         },
     }
@@ -296,7 +296,7 @@ pub fn out_attempt_v4_h2_custom_port(id: Id) -> Output {
         id,
         endpoint: Endpoint {
             address: SocketAddr::new(V4_ADDR.into(), CUSTOM_PORT),
-            protocol: ConnectionAttemptHttpVersions::H2,
+            http_version: ConnectionAttemptHttpVersions::H2,
             ech_config: None,
         },
     }

--- a/tests/connection_attempts.rs
+++ b/tests/connection_attempts.rs
@@ -142,7 +142,7 @@ fn successful_connection_cancels_others() {
                 id: Id::from(4),
                 endpoint: Endpoint {
                     address: SocketAddr::new(V6_ADDR_2.into(), PORT),
-                    protocol: ConnectionAttemptHttpVersions::H2OrH1,
+                    http_version: ConnectionAttemptHttpVersions::H2OrH1,
                     ech_config: None,
                 },
             }),

--- a/tests/hostname_resolution.rs
+++ b/tests/hostname_resolution.rs
@@ -433,7 +433,7 @@ fn multiple_ips_per_record() {
                 id: Id::from(4),
                 endpoint: Endpoint {
                     address: SocketAddr::new(V6_ADDR_2.into(), PORT),
-                    protocol: ConnectionAttemptHttpVersions::H2OrH1,
+                    http_version: ConnectionAttemptHttpVersions::H2OrH1,
                     ech_config: None,
                 },
             }),

--- a/tests/https_records.rs
+++ b/tests/https_records.rs
@@ -36,7 +36,7 @@ fn ech_config_propagated_to_endpoint() {
                     result: DnsResult::Https(Ok(vec![ServiceInfo {
                         priority: 1,
                         target_name: HOSTNAME.into(),
-                        alpn_protocols: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
                         ipv6_hints: vec![V6_ADDR],
                         ipv4_hints: vec![],
                         ech_config: Some(ECH_CONFIG.to_vec()),
@@ -47,7 +47,7 @@ fn ech_config_propagated_to_endpoint() {
                     id: Id::from(3),
                     endpoint: Endpoint {
                         address: SocketAddr::new(V6_ADDR.into(), PORT),
-                        protocol: ConnectionAttemptHttpVersions::H3,
+                        http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: Some(ECH_CONFIG.to_vec()),
                     },
                 }),
@@ -72,7 +72,7 @@ fn ech_config_from_https_applies_to_aaaa() {
                     result: DnsResult::Https(Ok(vec![ServiceInfo {
                         priority: 1,
                         target_name: HOSTNAME.into(),
-                        alpn_protocols: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
                         ipv6_hints: vec![],
                         ipv4_hints: vec![],
                         ech_config: Some(ECH_CONFIG.to_vec()),
@@ -87,7 +87,7 @@ fn ech_config_from_https_applies_to_aaaa() {
                     id: Id::from(3),
                     endpoint: Endpoint {
                         address: SocketAddr::new(V6_ADDR.into(), PORT),
-                        protocol: ConnectionAttemptHttpVersions::H3,
+                        http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: Some(ECH_CONFIG.to_vec()),
                     },
                 }),
@@ -119,7 +119,7 @@ fn multiple_target_names() {
                     id: Id::from(4),
                     endpoint: Endpoint {
                         address: SocketAddr::new(V6_ADDR_2.into(), PORT),
-                        protocol: ConnectionAttemptHttpVersions::H3,
+                        http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: None,
                     },
                 }),
@@ -156,7 +156,7 @@ mod https_port_svcparam_overrides_port_for {
                         result: DnsResult::Https(Ok(vec![ServiceInfo {
                             priority: 1,
                             target_name: HOSTNAME.into(),
-                            alpn_protocols: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+                            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
                             ipv6_hints: vec![V6_ADDR],
                             ipv4_hints,
                             ech_config: None,
@@ -199,7 +199,7 @@ fn https_port_svcparam_applies_to_resolved_a_and_aaaa() {
                     result: DnsResult::Https(Ok(vec![ServiceInfo {
                         priority: 1,
                         target_name: HOSTNAME.into(),
-                        alpn_protocols: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
                         ipv6_hints: vec![],
                         ipv4_hints: vec![],
                         ech_config: None,
@@ -243,7 +243,7 @@ fn https_port_svcparam_applies_but_fallbacks_follow() {
                     result: DnsResult::Https(Ok(vec![ServiceInfo {
                         priority: 1,
                         target_name: HOSTNAME.into(),
-                        alpn_protocols: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
                         ipv6_hints: vec![],
                         ipv4_hints: vec![],
                         ech_config: None,
@@ -259,7 +259,7 @@ fn https_port_svcparam_applies_but_fallbacks_follow() {
                     id: Id::from(3),
                     endpoint: Endpoint {
                         address: SocketAddr::new(V6_ADDR.into(), CUSTOM_PORT),
-                        protocol: ConnectionAttemptHttpVersions::H3,
+                        http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: None,
                     },
                 }),
@@ -307,16 +307,17 @@ fn https_two_service_infos_with_different_ports() {
     const PORT_2: u16 = 20008;
     let (mut now, mut he) = setup(); // PORT = 443
 
-    let attempt = |id: u64, addr: IpAddr, port: u16, protocol: ConnectionAttemptHttpVersions| {
-        Output::AttemptConnection {
-            id: Id::from(id),
-            endpoint: Endpoint {
-                address: SocketAddr::new(addr, port),
-                protocol,
-                ech_config: None,
-            },
-        }
-    };
+    let attempt =
+        |id: u64, addr: IpAddr, port: u16, http_version: ConnectionAttemptHttpVersions| {
+            Output::AttemptConnection {
+                id: Id::from(id),
+                endpoint: Endpoint {
+                    address: SocketAddr::new(addr, port),
+                    http_version,
+                    ech_config: None,
+                },
+            }
+        };
 
     he.expect(
         vec![
@@ -331,7 +332,7 @@ fn https_two_service_infos_with_different_ports() {
                         ServiceInfo {
                             priority: 1,
                             target_name: HOSTNAME.into(),
-                            alpn_protocols: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+                            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
                             ipv6_hints: vec![],
                             ipv4_hints: vec![],
                             ech_config: None,
@@ -340,7 +341,7 @@ fn https_two_service_infos_with_different_ports() {
                         ServiceInfo {
                             priority: 2,
                             target_name: HOSTNAME.into(),
-                            alpn_protocols: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+                            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
                             ipv6_hints: vec![],
                             ipv4_hints: vec![],
                             ech_config: None,
@@ -456,7 +457,7 @@ fn https_svc1_addresses_trigger_additional_attempts() {
                         ServiceInfo {
                             priority: 1,
                             target_name: HOSTNAME.into(),
-                            alpn_protocols: HashSet::from([HttpVersion::H2, HttpVersion::H3]),
+                            alpn_http_versions: HashSet::from([HttpVersion::H2, HttpVersion::H3]),
                             ipv6_hints: vec![],
                             ipv4_hints: vec![],
                             ech_config: None,
@@ -465,7 +466,7 @@ fn https_svc1_addresses_trigger_additional_attempts() {
                         ServiceInfo {
                             priority: 2,
                             target_name: SVC1.into(),
-                            alpn_protocols: HashSet::from([HttpVersion::H2, HttpVersion::H3]),
+                            alpn_http_versions: HashSet::from([HttpVersion::H2, HttpVersion::H3]),
                             ipv6_hints: vec![],
                             ipv4_hints: vec![],
                             ech_config: None,
@@ -514,12 +515,12 @@ fn https_svc1_addresses_trigger_additional_attempts() {
         now,
     );
 
-    let attempt = |id: u64, addr: IpAddr, protocol: ConnectionAttemptHttpVersions| {
+    let attempt = |id: u64, addr: IpAddr, http_version: ConnectionAttemptHttpVersions| {
         Output::AttemptConnection {
             id: Id::from(id),
             endpoint: Endpoint {
                 address: SocketAddr::new(addr, PORT),
-                protocol,
+                http_version,
                 ech_config: None,
             },
         }

--- a/tests/network_config.rs
+++ b/tests/network_config.rs
@@ -32,7 +32,7 @@ fn alt_svc_construction() {
         alt_svc: vec![AltSvc {
             host: None,
             port: None,
-            protocol: HttpVersion::H3,
+            http_version: HttpVersion::H3,
         }],
     };
     let mut he = HappyEyeballs::new_with_network_config(HOSTNAME, PORT, config).unwrap();
@@ -50,7 +50,7 @@ fn alt_svc_used_immediately() {
         alt_svc: vec![AltSvc {
             host: None,
             port: None,
-            protocol: HttpVersion::H3,
+            http_version: HttpVersion::H3,
         }],
     };
     let mut he = HappyEyeballs::new_with_network_config(HOSTNAME, PORT, config).unwrap();


### PR DESCRIPTION
More precise wording.

Fixes https://github.com/mozilla/happy-eyeballs/issues/28.