### PR TITLE
feat: handle alt-svc port

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,6 +353,16 @@ pub enum ConnectionAttemptHttpVersions {
     H1,
 }
 
+impl From<HttpVersion> for ConnectionAttemptHttpVersions {
+    fn from(v: HttpVersion) -> Self {
+        match v {
+            HttpVersion::H3 => ConnectionAttemptHttpVersions::H3,
+            HttpVersion::H2 => ConnectionAttemptHttpVersions::H2,
+            HttpVersion::H1 => ConnectionAttemptHttpVersions::H1,
+        }
+    }
+}
+
 impl ConnectionAttemptHttpVersions {
     /// [`HttpVersion::H2`] and [`HttpVersion::H1`] into [`ConnectionAttemptHttpVersions::H2OrH1`].
     fn from_alpn(http_versions: &HashSet<HttpVersion>) -> HashSet<ConnectionAttemptHttpVersions> {
@@ -1061,6 +1071,42 @@ impl HappyEyeballs {
             endpoints.extend(bucket);
         }
 
+        // Alt-svc endpoints with custom port.
+        //
+        // These use the origin domain's resolved addresses at the alt-svc port.
+        // HTTPS record endpoints above take precedence by virtue of ordering.
+        for alt_svc in &self.network_config.alt_svc {
+            if alt_svc.host.is_some() {
+                // Alt-svc host resolution not yet implemented.
+                continue;
+            }
+            let Some(alt_port) = alt_svc.port else {
+                continue;
+            };
+
+            let alt_http_version: ConnectionAttemptHttpVersions = alt_svc.http_version.into();
+            if !http_versions.contains(&alt_http_version) {
+                continue;
+            }
+            let alt_http_versions = HashSet::from([alt_http_version]);
+
+            let mut bucket: Vec<Endpoint> = self
+                .dns_queries
+                .iter()
+                .filter_map(|q| match q {
+                    DnsQuery::Completed {
+                        target_name,
+                        response: r @ (DnsResult::Aaaa(_) | DnsResult::A(_)),
+                        ..
+                    } if target_name.as_str() == origin_domain => Some(r),
+                    _ => None,
+                })
+                .flat_map(|r| r.flatten_into_endpoints(alt_port, &alt_http_versions))
+                .collect();
+            bucket.sort_by(|a, b| a.sort_with_config(b, &self.network_config));
+            endpoints.extend(bucket);
+        }
+
         // Fallback to AAAA and A of the original hostname only.
         let mut bucket: Vec<Endpoint> = self
             .dns_queries
@@ -1134,8 +1180,8 @@ impl HappyEyeballs {
         // Add HTTP versions from alt-svc
         for alt_svc in &self.network_config.alt_svc {
             debug_assert!(
-                alt_svc.host.is_none() && alt_svc.port.is_none(),
-                "alt-svc with custom host/port not yet supported"
+                alt_svc.host.is_none(),
+                "alt-svc with custom host not yet supported"
             );
             http_versions.insert(alt_svc.http_version);
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::HashSet,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::Instant,
 };
 
@@ -297,6 +297,22 @@ pub fn out_attempt_v4_h2_custom_port(id: Id) -> Output {
         endpoint: Endpoint {
             address: SocketAddr::new(V4_ADDR.into(), CUSTOM_PORT),
             http_version: ConnectionAttemptHttpVersions::H2,
+            ech_config: None,
+        },
+    }
+}
+
+pub fn out_attempt(
+    id: Id,
+    addr: IpAddr,
+    port: u16,
+    http_version: ConnectionAttemptHttpVersions,
+) -> Output {
+    Output::AttemptConnection {
+        id,
+        endpoint: Endpoint {
+            address: SocketAddr::new(addr, port),
+            http_version,
             ech_config: None,
         },
     }

--- a/tests/https_records.rs
+++ b/tests/https_records.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 use happy_eyeballs::{
-    ConnectionAttemptHttpVersions, DnsRecordType, DnsResult, Endpoint, HttpVersion, Id, Input,
-    Output, ServiceInfo,
+    AltSvc, ConnectionAttemptHttpVersions, DnsRecordType, DnsResult, Endpoint, HttpVersion,
+    HttpVersions, Id, Input, IpPreference, NetworkConfig, Output, ServiceInfo,
 };
 
 #[test]
@@ -539,6 +539,132 @@ fn https_svc1_addresses_trigger_additional_attempts() {
             attempt(10, V4_ADDR_2.into(), ConnectionAttemptHttpVersions::H3), // priority=2
             attempt(11, V6_ADDR_2.into(), ConnectionAttemptHttpVersions::H2), // priority=2
             attempt(12, V4_ADDR_2.into(), ConnectionAttemptHttpVersions::H2), // priority=2
+        ],
+    );
+}
+
+/// HTTPS record port takes precedence over alt-svc port.
+///
+/// HTTPS record with port=8443 and H3+H2; alt-svc with port=9443 and H3.
+/// Expected order:
+///   HTTPS bucket    (port 8443): V6:H3, V4:H3, V6:H2, V4:H2
+///   alt-svc bucket  (port 9443): V6:H3, V4:H3
+///   fallback bucket (port  443): V6:H3, V4:H3, V6:H2, V4:H2
+#[test]
+fn https_port_takes_precedence_over_alt_svc_port() {
+    const HTTPS_PORT: u16 = 8443;
+    const ALT_SVC_PORT: u16 = 9443;
+
+    let config = NetworkConfig {
+        http_versions: HttpVersions::default(),
+        ip: IpPreference::DualStackPreferV6,
+        alt_svc: vec![AltSvc {
+            host: None,
+            port: Some(ALT_SVC_PORT),
+            http_version: HttpVersion::H3,
+        }],
+    };
+    let (mut now, mut he) = setup_with_config(config);
+
+    he.expect(
+        vec![
+            (None, Some(out_send_dns_https(Id::from(0)))),
+            (None, Some(out_send_dns_aaaa(Id::from(1)))),
+            (None, Some(out_send_dns_a(Id::from(2)))),
+            // HTTPS record with port=8443
+            (
+                Some(Input::DnsResult {
+                    id: Id::from(0),
+                    result: DnsResult::Https(Ok(vec![ServiceInfo {
+                        priority: 1,
+                        target_name: HOSTNAME.into(),
+                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+                        ipv6_hints: vec![],
+                        ipv4_hints: vec![],
+                        ech_config: None,
+                        port: Some(HTTPS_PORT),
+                    }])),
+                }),
+                Some(out_resolution_delay()),
+            ),
+            // AAAA arrives; HTTPS bucket first (port 8443)
+            (
+                Some(in_dns_aaaa_positive(Id::from(1))),
+                Some(out_attempt(
+                    Id::from(3),
+                    V6_ADDR.into(),
+                    HTTPS_PORT,
+                    ConnectionAttemptHttpVersions::H3,
+                )),
+            ),
+            (
+                Some(in_dns_a_positive(Id::from(2))),
+                Some(out_connection_attempt_delay()),
+            ),
+        ],
+        now,
+    );
+
+    he.expect_connection_attempts(
+        &mut now,
+        vec![
+            // HTTPS bucket (port 8443)
+            out_attempt(
+                Id::from(4),
+                V4_ADDR.into(),
+                HTTPS_PORT,
+                ConnectionAttemptHttpVersions::H3,
+            ),
+            out_attempt(
+                Id::from(5),
+                V6_ADDR.into(),
+                HTTPS_PORT,
+                ConnectionAttemptHttpVersions::H2,
+            ),
+            out_attempt(
+                Id::from(6),
+                V4_ADDR.into(),
+                HTTPS_PORT,
+                ConnectionAttemptHttpVersions::H2,
+            ),
+            // Alt-svc bucket (port 9443)
+            out_attempt(
+                Id::from(7),
+                V6_ADDR.into(),
+                ALT_SVC_PORT,
+                ConnectionAttemptHttpVersions::H3,
+            ),
+            out_attempt(
+                Id::from(8),
+                V4_ADDR.into(),
+                ALT_SVC_PORT,
+                ConnectionAttemptHttpVersions::H3,
+            ),
+            // Fallback bucket (port 443)
+            out_attempt(
+                Id::from(9),
+                V6_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H3,
+            ),
+            out_attempt(
+                Id::from(10),
+                V4_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H3,
+            ),
+            out_attempt(
+                Id::from(11),
+                V6_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H2,
+            ),
+            out_attempt(
+                Id::from(12),
+                V4_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H2,
+            ),
         ],
     );
 }

--- a/tests/network_config.rs
+++ b/tests/network_config.rs
@@ -5,7 +5,8 @@ use common::*;
 use std::time::Instant;
 
 use happy_eyeballs::{
-    AltSvc, HappyEyeballs, HttpVersion, HttpVersions, Id, IpPreference, NetworkConfig,
+    AltSvc, ConnectionAttemptHttpVersions, HappyEyeballs, HttpVersion, HttpVersions, Id,
+    IpPreference, NetworkConfig,
 };
 
 #[test]
@@ -72,5 +73,92 @@ fn alt_svc_used_immediately() {
             ),
         ],
         now,
+    );
+}
+
+/// Alt-svc with a custom port: connections are attempted at both the alt-svc
+/// port and the origin port.
+///
+/// No HTTPS records in this scenario. Alt-svc says H3 on port 8443.
+/// Expected endpoint order:
+///   alt-svc bucket  (port 8443): V6:H3, V4:H3
+///   fallback bucket (port  443): V6:H3, V4:H3, V6:H2OrH1, V4:H2OrH1
+#[test]
+fn alt_svc_with_port() {
+    let alt_port: u16 = CUSTOM_PORT;
+    let config = NetworkConfig {
+        http_versions: HttpVersions::default(),
+        ip: IpPreference::DualStackPreferV6,
+        alt_svc: vec![AltSvc {
+            host: None,
+            port: Some(alt_port),
+            http_version: HttpVersion::H3,
+        }],
+    };
+    let (mut now, mut he) = setup_with_config(config);
+
+    he.expect(
+        vec![
+            (None, Some(out_send_dns_https(Id::from(0)))),
+            (None, Some(out_send_dns_aaaa(Id::from(1)))),
+            (None, Some(out_send_dns_a(Id::from(2)))),
+            (
+                Some(in_dns_https_negative(Id::from(0))),
+                Some(out_resolution_delay()),
+            ),
+            // AAAA arrives, move-on met. First endpoint: alt-svc port V6:H3
+            (
+                Some(in_dns_aaaa_positive(Id::from(1))),
+                Some(out_attempt(
+                    Id::from(3),
+                    V6_ADDR.into(),
+                    alt_port,
+                    ConnectionAttemptHttpVersions::H3,
+                )),
+            ),
+            (
+                Some(in_dns_a_positive(Id::from(2))),
+                Some(out_connection_attempt_delay()),
+            ),
+        ],
+        now,
+    );
+
+    he.expect_connection_attempts(
+        &mut now,
+        vec![
+            // Alt-svc bucket (port 8443): V4:H3
+            out_attempt(
+                Id::from(4),
+                V4_ADDR.into(),
+                alt_port,
+                ConnectionAttemptHttpVersions::H3,
+            ),
+            // Fallback bucket (port 443): V6:H3, V4:H3, V6:H2OrH1, V4:H2OrH1
+            out_attempt(
+                Id::from(5),
+                V6_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H3,
+            ),
+            out_attempt(
+                Id::from(6),
+                V4_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H3,
+            ),
+            out_attempt(
+                Id::from(7),
+                V6_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H2OrH1,
+            ),
+            out_attempt(
+                Id::from(8),
+                V4_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H2OrH1,
+            ),
+        ],
     );
 }


### PR DESCRIPTION
When alt-svc specifies a port, generate connection attempt endpoints at that port using the origin domain's resolved addresses. HTTPS record endpoints take precedence over alt-svc by virtue of ordering.

Discussed in https://github.com/mozilla/happy-eyeballs/issues/24.

CC @zirngibl. Note that this is a first version only, though in line with your suggestion to still use and prioritize HTTPS RR. 