### PR TITLE
chore(Cargo.toml): prepare v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "happy-eyeballs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "happy-eyeballs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Once https://github.com/mozilla/happy-eyeballs/pull/41 merged, I would like to cut `v0.3.0`.

Objections @KershawChang?