### PR TITLE
Handle alt-svc as separate (version, port) pairs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,6 +523,14 @@ impl NetworkConfig {
             IpPreference::DualStackPreferV4 | IpPreference::Ipv4Only => DnsRecordType::A,
         }
     }
+
+    fn is_http_version_disabled(&self, http_version: HttpVersion) -> bool {
+        match http_version {
+            HttpVersion::H3 => !self.http_versions.h3,
+            HttpVersion::H2 => !self.http_versions.h2,
+            HttpVersion::H1 => !self.http_versions.h1,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1031,16 +1039,16 @@ impl HappyEyeballs {
     }
 
     fn endpoints_to_attempt_ip(&self, ip: IpAddr) -> Vec<Endpoint> {
-        let mut endpoints: Vec<Endpoint> = self
-            .ip_host_http_versions()
-            .into_iter()
-            .map(|http_version| Endpoint {
-                address: SocketAddr::new(ip, self.port),
+        let mut endpoints: Vec<Endpoint> = Vec::new();
+        for (http_version, port) in self.origin_version_port_pairs() {
+            let mut bucket = vec![Endpoint {
+                address: SocketAddr::new(ip, port),
                 http_version,
                 ech_config: None,
-            })
-            .collect();
-        endpoints.sort_by(|a, b| a.cmp_with_config(b, &self.network_config));
+            }];
+            bucket.sort_by(|a, b| a.cmp_with_config(b, &self.network_config));
+            endpoints.extend(bucket);
+        }
         endpoints
     }
 
@@ -1104,25 +1112,8 @@ impl HappyEyeballs {
         // Alt-svc and fallback endpoints use the origin domain without ECH.
         // Only include them when ECH is not required.
         if !any_ech {
-            // Alt-svc endpoints with custom port.
-            //
-            // These use the origin domain's resolved addresses at the alt-svc port.
-            // HTTPS record endpoints above take precedence by virtue of ordering.
-            for alt_svc in &self.network_config.alt_svc {
-                if alt_svc.host.is_some() {
-                    // Alt-svc host resolution not yet implemented.
-                    continue;
-                }
-                let Some(alt_port) = alt_svc.port else {
-                    continue;
-                };
-
-                let alt_http_version: ConnectionAttemptHttpVersions = alt_svc.http_version.into();
-                if !http_versions.contains(&alt_http_version) {
-                    continue;
-                }
-                let alt_http_versions = HashSet::from([alt_http_version]);
-
+            for (http_version, port) in self.origin_version_port_pairs() {
+                let http_versions = HashSet::from([http_version]);
                 let mut bucket: Vec<Endpoint> = self
                     .dns_queries
                     .iter()
@@ -1133,32 +1124,11 @@ impl HappyEyeballs {
                         } if q.target_name.as_str() == origin_domain => Some(r),
                         _ => None,
                     })
-                    .flat_map(|r| r.flatten_into_endpoints(alt_port, &alt_http_versions))
+                    .flat_map(|r| r.flatten_into_endpoints(port, &http_versions))
                     .collect();
                 bucket.sort_by(|a, b| a.cmp_with_config(b, &self.network_config));
                 endpoints.extend(bucket);
             }
-
-            // Fallback to AAAA and A of the original hostname only.
-            //
-            // The fallback uses default HTTP versions (H2/H1), not those
-            // derived from HTTPS records, since HTTPS record parameters
-            // (like H3 or custom ports) do not apply to the origin fallback.
-            let fallback_http_versions = self.fallback_http_versions();
-            let mut bucket: Vec<Endpoint> = self
-                .dns_queries
-                .iter()
-                .filter_map(|q| match &q.state {
-                    DnsQueryState::Completed {
-                        response: r @ (DnsResult::Aaaa(_) | DnsResult::A(_)),
-                        ..
-                    } if q.target_name.as_str() == origin_domain => Some(r),
-                    _ => None,
-                })
-                .flat_map(|r| r.flatten_into_endpoints(self.port, &fallback_http_versions))
-                .collect();
-            bucket.sort_by(|a, b| a.cmp_with_config(b, &self.network_config));
-            endpoints.extend(bucket);
         }
 
         endpoints
@@ -1206,17 +1176,16 @@ impl HappyEyeballs {
 
     /// HTTP versions when the host is an IP address (no DNS involved).
     ///
-    /// Default H2/H1 plus alt-svc, filtered by network config.
+    /// Default H2/H1, filtered by network config.
     fn ip_host_http_versions(&self) -> HashSet<ConnectionAttemptHttpVersions> {
         let mut http_versions = HashSet::from([HttpVersion::H2, HttpVersion::H1]);
-        self.add_alt_svc_http_versions(&mut http_versions);
         self.filter_disabled_http_versions(&mut http_versions);
         ConnectionAttemptHttpVersions::from_http_versions(&http_versions)
     }
 
     /// HTTP versions for HTTPS record (ServiceInfo) endpoints.
     ///
-    /// Uses ALPNs from HTTPS records plus alt-svc. Falls back to H2/H1 when
+    /// Uses ALPNs from HTTPS records. Falls back to H2/H1 when
     /// HTTPS records specify no versions. Filtered by network config.
     fn https_record_http_versions(&self) -> HashSet<ConnectionAttemptHttpVersions> {
         let mut http_versions = HashSet::new();
@@ -1243,27 +1212,46 @@ impl HappyEyeballs {
             http_versions.insert(HttpVersion::H1);
         }
 
-        self.add_alt_svc_http_versions(&mut http_versions);
         self.filter_disabled_http_versions(&mut http_versions);
         ConnectionAttemptHttpVersions::from_http_versions(&http_versions)
     }
 
     /// HTTP versions for the origin fallback bucket.
     ///
-    /// Default H2/H1 plus alt-svc, filtered by network config.
+    /// Default H2/H1, filtered by network config.
     /// HTTPS-record ALPNs are excluded: those apply only to the HTTPS bucket.
     fn fallback_http_versions(&self) -> HashSet<ConnectionAttemptHttpVersions> {
         self.ip_host_http_versions()
     }
 
-    fn add_alt_svc_http_versions(&self, http_versions: &mut HashSet<HttpVersion>) {
+    /// (http_version, port) pairs for origin endpoints (alt-svc and defaults).
+    ///
+    /// Combines:
+    /// 1. Alt-svc entries (custom port or origin port)
+    /// 2. Default HTTP versions (H2/H1) at the origin port
+    fn origin_version_port_pairs(&self) -> Vec<(ConnectionAttemptHttpVersions, u16)> {
+        let mut pairs = Vec::new();
+
         for alt_svc in &self.network_config.alt_svc {
             debug_assert!(
                 alt_svc.host.is_none(),
                 "alt-svc with custom host not yet supported"
             );
-            http_versions.insert(alt_svc.http_version);
+            if self
+                .network_config
+                .is_http_version_disabled(alt_svc.http_version)
+            {
+                continue;
+            }
+            let port = alt_svc.port.unwrap_or(self.port);
+            pairs.push((alt_svc.http_version.into(), port));
         }
+
+        for http_version in self.fallback_http_versions() {
+            pairs.push((http_version, self.port));
+        }
+
+        pairs
     }
 
     fn filter_disabled_http_versions(&self, http_versions: &mut HashSet<HttpVersion>) {

--- a/tests/https_records.rs
+++ b/tests/https_records.rs
@@ -978,7 +978,7 @@ fn https_svc1_addresses_trigger_additional_attempts() {
 /// Expected order:
 ///   HTTPS bucket    (port 8443): V6:H3, V4:H3, V6:H2, V4:H2
 ///   alt-svc bucket  (port 9443): V6:H3, V4:H3
-///   fallback bucket (port  443): V6:H3, V4:H3, V6:H2OrH1, V4:H2OrH1
+///   fallback bucket (port  443): V6:H2OrH1, V4:H2OrH1
 #[test]
 fn https_port_takes_precedence_over_alt_svc_port() {
     const HTTPS_PORT: u16 = 8443;
@@ -1068,27 +1068,15 @@ fn https_port_takes_precedence_over_alt_svc_port() {
                 ALT_SVC_PORT,
                 ConnectionAttemptHttpVersions::H3,
             ),
-            // Fallback bucket (port 443) uses default versions plus alt-svc H3.
+            // Fallback bucket (port 443) uses default versions only.
             out_attempt(
                 Id::from(9),
-                V6_ADDR.into(),
-                PORT,
-                ConnectionAttemptHttpVersions::H3,
-            ),
-            out_attempt(
-                Id::from(10),
-                V4_ADDR.into(),
-                PORT,
-                ConnectionAttemptHttpVersions::H3,
-            ),
-            out_attempt(
-                Id::from(11),
                 V6_ADDR.into(),
                 PORT,
                 ConnectionAttemptHttpVersions::H2OrH1,
             ),
             out_attempt(
-                Id::from(12),
+                Id::from(10),
                 V4_ADDR.into(),
                 PORT,
                 ConnectionAttemptHttpVersions::H2OrH1,

--- a/tests/network_config.rs
+++ b/tests/network_config.rs
@@ -78,7 +78,7 @@ fn alt_svc_used_immediately() {
 /// No HTTPS records in this scenario. Alt-svc says H3 on port 8443.
 /// Expected endpoint order:
 ///   alt-svc bucket  (port 8443): V6:H3, V4:H3
-///   fallback bucket (port  443): V6:H3, V4:H3, V6:H2OrH1, V4:H2OrH1
+///   fallback bucket (port  443): V6:H2OrH1, V4:H2OrH1
 #[test]
 fn alt_svc_with_port() {
     let alt_port: u16 = CUSTOM_PORT;
@@ -129,27 +129,66 @@ fn alt_svc_with_port() {
                 alt_port,
                 ConnectionAttemptHttpVersions::H3,
             ),
-            // Fallback bucket (port 443): V6:H3, V4:H3, V6:H2OrH1, V4:H2OrH1
+            // Fallback bucket (port 443): V6:H2OrH1, V4:H2OrH1
             out_attempt(
                 Id::from(5),
-                V6_ADDR.into(),
-                PORT,
-                ConnectionAttemptHttpVersions::H3,
-            ),
-            out_attempt(
-                Id::from(6),
-                V4_ADDR.into(),
-                PORT,
-                ConnectionAttemptHttpVersions::H3,
-            ),
-            out_attempt(
-                Id::from(7),
                 V6_ADDR.into(),
                 PORT,
                 ConnectionAttemptHttpVersions::H2OrH1,
             ),
             out_attempt(
-                Id::from(8),
+                Id::from(6),
+                V4_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H2OrH1,
+            ),
+        ],
+    );
+}
+
+/// When the host is an IP address and alt-svc specifies a custom port,
+/// endpoints should be attempted at both the alt-svc port and the origin port.
+///
+/// Expected endpoint order:
+///   alt-svc bucket  (port 8443): V4_ADDR:H3
+///   fallback bucket (port  443): V4_ADDR:H2OrH1
+#[test]
+fn ip_host_alt_svc_with_port() {
+    let mut now = Instant::now();
+    let config = NetworkConfig {
+        alt_svc: vec![AltSvc {
+            host: None,
+            port: Some(CUSTOM_PORT),
+            http_version: HttpVersion::H3,
+        }],
+        ..NetworkConfig::default()
+    };
+    let mut he =
+        HappyEyeballs::new_with_network_config(&V4_ADDR.to_string(), PORT, config).unwrap();
+
+    he.expect(
+        vec![
+            // Alt-svc bucket (port 8443): H3
+            (
+                None,
+                Some(out_attempt(
+                    Id::from(0),
+                    V4_ADDR.into(),
+                    CUSTOM_PORT,
+                    ConnectionAttemptHttpVersions::H3,
+                )),
+            ),
+            (None, Some(out_connection_attempt_delay())),
+        ],
+        now,
+    );
+
+    he.expect_connection_attempts(
+        &mut now,
+        vec![
+            // Fallback bucket (port 443): H2OrH1
+            out_attempt(
+                Id::from(1),
                 V4_ADDR.into(),
                 PORT,
                 ConnectionAttemptHttpVersions::H2OrH1,


### PR DESCRIPTION
Alt-svc HTTP versions were previously mixed into the base version set, causing alt-svc versions (e.g. H3) to appear at the origin port even when the alt-svc specified a custom port.

Fixes https://github.com/mozilla/happy-eyeballs/issues/44.

---

@KershawChang do you agree that we should e.g. not try H3 on `:443` if the alt-svc was e.g. `Alt-Svc: h4=":8443";`. (Note the `8` in the alt-svc port.) See also test at the very bottom.