### PR TITLE
Consider HTTPS IP hints as positive address answers in timeout path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,24 +91,15 @@ pub enum DnsResult {
 }
 
 impl DnsResult {
-    fn record_type(&self) -> DnsRecordType {
+    /// Returns true if this result provides address information, i.e.
+    /// non-empty AAAA/A records or HTTPS records with IP hints.
+    fn has_addrs(&self) -> bool {
         match self {
-            DnsResult::Https(_) => DnsRecordType::Https,
-            DnsResult::Aaaa(_) => DnsRecordType::Aaaa,
-            DnsResult::A(_) => DnsRecordType::A,
-        }
-    }
-
-    /// Returns true if this result contains at least one non-empty record.
-    ///
-    /// > Some positive (non-empty) address answers have been received
-    ///
-    /// <https://www.ietf.org/archive/id/draft-ietf-happy-happyeyeballs-v3-02.html#section-4.2>
-    fn positive(&self) -> bool {
-        match self {
-            DnsResult::Https(Ok(v)) => !v.is_empty(),
             DnsResult::Aaaa(Ok(v)) => !v.is_empty(),
             DnsResult::A(Ok(v)) => !v.is_empty(),
+            DnsResult::Https(Ok(infos)) => infos
+                .iter()
+                .any(|i| !i.ipv4_hints.is_empty() || !i.ipv6_hints.is_empty()),
             _ => false,
         }
     }
@@ -1280,14 +1271,7 @@ impl HappyEyeballs {
         //
         // <https://www.ietf.org/archive/id/draft-ietf-happy-happyeyeballs-v3-02.html#section-4.2>
         if !self.dns_queries.iter().any(|q| match &q.state {
-            DnsQueryState::Completed { response, .. } => match response {
-                DnsResult::Aaaa(Ok(addrs)) => !addrs.is_empty(),
-                DnsResult::A(Ok(addrs)) => !addrs.is_empty(),
-                DnsResult::Https(Ok(infos)) => infos
-                    .iter()
-                    .any(|i| !i.ipv4_hints.is_empty() || !i.ipv6_hints.is_empty()),
-                _ => false,
-            },
+            DnsQueryState::Completed { response, .. } => response.has_addrs(),
             DnsQueryState::InProgress => false,
         }) {
             return false;
@@ -1331,13 +1315,12 @@ impl HappyEyeballs {
         //
         // <https://www.ietf.org/archive/id/draft-ietf-happy-happyeyeballs-v3-02.html#section-4.2>
 
-        let mut positive_responses = self
+        if !self
             .dns_queries
             .iter()
             .filter_map(|q| q.response())
-            .filter(|r| r.positive())
-            .filter(|r| matches!(r.record_type(), DnsRecordType::Aaaa | DnsRecordType::A));
-        if positive_responses.next().is_none() {
+            .any(|r| r.has_addrs())
+        {
             return false;
         }
 

--- a/tests/hostname_resolution.rs
+++ b/tests/hostname_resolution.rs
@@ -321,6 +321,35 @@ fn https_hints() {
     );
 }
 
+/// HTTPS IP hints should count as positive address answers for the
+/// resolution delay timeout path (`move_on_with_timeout`).
+///
+/// Scenario: only HTTPS with v6 hints has arrived, AAAA and A are still
+/// in-progress. After the resolution delay we should move on.
+///
+/// <https://github.com/mozilla/happy-eyeballs/issues/39>
+#[test]
+fn https_hints_move_on_with_timeout() {
+    let (mut now, mut he) = setup();
+
+    he.expect(
+        vec![
+            (None, Some(out_send_dns_https(Id::from(0)))),
+            (None, Some(out_send_dns_aaaa(Id::from(1)))),
+            (None, Some(out_send_dns_a(Id::from(2)))),
+            (
+                Some(in_dns_https_positive_v6_hints(Id::from(0))),
+                Some(out_resolution_delay()),
+            ),
+        ],
+        now,
+    );
+
+    now += RESOLUTION_DELAY;
+
+    he.expect(vec![(None, Some(out_attempt_v6_h3(Id::from(3))))], now);
+}
+
 /// > Note that clients are still required to issue A and AAAA queries
 /// > for those TargetNames if they haven't yet received those records.
 ///


### PR DESCRIPTION
`move_on_with_timeout` only considered AAAA/A records as positive address answers, ignoring HTTPS records with IP hints. This meant that when only an HTTPS response with hints had arrived, the resolution delay timeout would never trigger the connection phase.

Extract `DnsResult::has_addrs()` to unify the check across both `move_on_without_timeout` and `move_on_with_timeout`.

Fixes #39.