### PR TITLE
Skip disabled address family in target-name follow-up queries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,6 +441,26 @@ pub enum IpPreference {
     Ipv4Only,
 }
 
+impl IpPreference {
+    fn address_record_types(&self) -> impl Iterator<Item = DnsRecordType> {
+        let aaaa = matches!(
+            self,
+            IpPreference::DualStackPreferV6
+                | IpPreference::DualStackPreferV4
+                | IpPreference::Ipv6Only
+        )
+        .then_some(DnsRecordType::Aaaa);
+        let a = matches!(
+            self,
+            IpPreference::DualStackPreferV6
+                | IpPreference::DualStackPreferV4
+                | IpPreference::Ipv4Only
+        )
+        .then_some(DnsRecordType::A);
+        aaaa.into_iter().chain(a)
+    }
+}
+
 /// Alternative service information from previous connections.
 ///
 /// See [RFC 7838](https://datatracker.ietf.org/doc/html/rfc7838).
@@ -808,18 +828,9 @@ impl HappyEyeballs {
         }
         .into();
 
-        for record_type in [DnsRecordType::Https, DnsRecordType::Aaaa, DnsRecordType::A] {
-            // Skip address family queries that don't match the network configuration.
-            if record_type == DnsRecordType::Aaaa
-                && matches!(self.network_config.ip, IpPreference::Ipv4Only)
-            {
-                continue;
-            }
-            if record_type == DnsRecordType::A
-                && matches!(self.network_config.ip, IpPreference::Ipv6Only)
-            {
-                continue;
-            }
+        let record_types = std::iter::once(DnsRecordType::Https)
+            .chain(self.network_config.ip.address_record_types());
+        for record_type in record_types {
             if !self
                 .dns_queries
                 .iter()
@@ -866,9 +877,14 @@ impl HappyEyeballs {
             .filter(move |i| !any_ech || i.ech_config.is_some())
             .map(|i| &i.target_name);
 
-        // Next AAAA or A query.
+        // Next AAAA or A query, respecting single-stack preferences.
         let (target_name, record_type) = target_names
-            .flat_map(|tn| [(tn, DnsRecordType::Aaaa), (tn, DnsRecordType::A)])
+            .flat_map(|tn| {
+                self.network_config
+                    .ip
+                    .address_record_types()
+                    .map(move |rt| (tn, rt))
+            })
             .find(|(tn, rt)| {
                 !self
                     .dns_queries

--- a/tests/hostname_resolution.rs
+++ b/tests/hostname_resolution.rs
@@ -7,8 +7,8 @@ use common::*;
 use std::{net::SocketAddr, time::Duration};
 
 use happy_eyeballs::{
-    CONNECTION_ATTEMPT_DELAY, ConnectionAttemptHttpVersions, DnsResult, Endpoint, HttpVersions, Id,
-    Input, IpPreference, NetworkConfig, Output, RESOLUTION_DELAY,
+    CONNECTION_ATTEMPT_DELAY, ConnectionAttemptHttpVersions, DnsRecordType, DnsResult, Endpoint,
+    HttpVersions, Id, Input, IpPreference, NetworkConfig, Output, RESOLUTION_DELAY,
 };
 
 #[test]
@@ -513,6 +513,60 @@ fn single_stack_skips_disabled_address_family() {
                     Some(out_resolution_delay()),
                 ),
                 (Some(case.dns_response), Some(case.expected_connection)),
+            ],
+            now,
+        );
+    }
+}
+
+/// On a single-stack network, target-name follow-up queries must also skip
+/// the disabled address family.
+///
+/// <https://github.com/mozilla/happy-eyeballs/issues/38>
+#[test]
+fn single_stack_target_name_skips_disabled_address_family() {
+    struct Case {
+        ip: IpPreference,
+        /// The only address-family query sent for the origin domain.
+        origin_dns_query: Output,
+        /// The only address-family query sent for the target name.
+        target_name_dns_query: Output,
+    }
+
+    let cases = vec![
+        Case {
+            ip: IpPreference::Ipv6Only,
+            origin_dns_query: out_send_dns_aaaa(Id::from(1)),
+            target_name_dns_query: out_send_dns_svc1(Id::from(2)),
+        },
+        Case {
+            ip: IpPreference::Ipv4Only,
+            origin_dns_query: out_send_dns_a(Id::from(1)),
+            target_name_dns_query: Output::SendDnsQuery {
+                id: Id::from(2),
+                hostname: SVC1.into(),
+                record_type: DnsRecordType::A,
+            },
+        },
+    ];
+
+    for case in cases {
+        let (now, mut he) = setup_with_config(NetworkConfig {
+            ip: case.ip,
+            ..NetworkConfig::default()
+        });
+
+        he.expect(
+            vec![
+                (None, Some(out_send_dns_https(Id::from(0)))),
+                (None, Some(case.origin_dns_query)),
+                (
+                    Some(in_dns_https_positive_svc1(Id::from(0))),
+                    Some(case.target_name_dns_query),
+                ),
+                // No query for the disabled address family should appear,
+                // only the resolution delay.
+                (None, Some(out_resolution_delay())),
             ],
             now,
         );


### PR DESCRIPTION
`send_dns_request_for_target_name` always queried both AAAA and A records for target names from HTTPS responses, ignoring the network's `IpPreference`. On an IPv6-only network this sent unnecessary A queries; on IPv4-only, unnecessary AAAA queries.

Extract `IpPreference::address_record_types()` and use it in both `send_dns_request` and `send_dns_request_for_target_name`.

Fixes #38.