### PR TITLE
Support disabling ECH via NetworkConfig

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,7 @@ impl ServiceInfo {
         ipv4_addrs: &[Ipv4Addr],
         ipv6_addrs: &[Ipv6Addr],
         http_versions: &HashSet<ConnectionAttemptHttpVersions>,
+        ech_enabled: bool,
     ) -> Vec<Endpoint> {
         let port = self.port.unwrap_or(port);
 
@@ -297,7 +298,7 @@ impl ServiceInfo {
             .chain(hint_v4.iter().cloned().map(IpAddr::V4))
             .flat_map(|ip| {
                 // TODO: way around allocation?
-                let ech_config = self.ech_config.clone();
+                let ech_config = ech_enabled.then(|| self.ech_config.clone()).flatten();
                 hint_http_versions
                     .iter()
                     .map(move |&http_version| Endpoint {
@@ -314,7 +315,7 @@ impl ServiceInfo {
             .chain(ipv4_addrs.iter().cloned().map(IpAddr::V4))
             .flat_map(|ip| {
                 // TODO: way around allocation?
-                let ech_config = self.ech_config.clone();
+                let ech_config = ech_enabled.then(|| self.ech_config.clone()).flatten();
                 http_versions.iter().map(move |v| Endpoint {
                     address: SocketAddr::new(ip, port),
                     http_version: *v,
@@ -506,6 +507,14 @@ pub struct NetworkConfig {
     /// Defaults to [`CONNECTION_ATTEMPT_DELAY`] (250 ms) per
     /// <https://www.ietf.org/archive/id/draft-ietf-happy-happyeyeballs-v3-02.html#section-9>.
     pub connection_attempt_delay: Duration,
+    /// Whether Encrypted Client Hello (ECH) is enabled.
+    ///
+    /// When `false`, ECH configs from HTTPS records are ignored: endpoints
+    /// always get `ech_config: None` and the ECH-based filtering (skip
+    /// non-ECH ServiceInfos, skip origin fallback) does not apply.
+    ///
+    /// Defaults to `true`.
+    pub ech: bool,
 }
 
 impl Default for NetworkConfig {
@@ -516,6 +525,7 @@ impl Default for NetworkConfig {
             alt_svc: Vec::new(),
             resolution_delay: RESOLUTION_DELAY,
             connection_attempt_delay: CONNECTION_ATTEMPT_DELAY,
+            ech: true,
         }
     }
 }
@@ -1110,8 +1120,13 @@ impl HappyEyeballs {
                 .flatten()
                 .cloned()
                 .collect();
-            let mut bucket =
-                info.flatten_into_endpoints(self.port, &ipv4_addrs, &ipv6_addrs, &http_versions);
+            let mut bucket = info.flatten_into_endpoints(
+                self.port,
+                &ipv4_addrs,
+                &ipv6_addrs,
+                &http_versions,
+                self.network_config.ech,
+            );
             bucket.sort_by(|a, b| a.cmp_with_config(b, &self.network_config));
             endpoints.extend(bucket);
         }
@@ -1172,6 +1187,9 @@ impl HappyEyeballs {
     }
 
     fn any_ech(&self) -> bool {
+        if !self.network_config.ech {
+            return false;
+        }
         self.dns_queries.iter().any(|q| match &q.state {
             DnsQueryState::Completed {
                 response: DnsResult::Https(Ok(infos)),

--- a/tests/https_records.rs
+++ b/tests/https_records.rs
@@ -57,6 +57,78 @@ fn ech_config_propagated_to_endpoint() {
     );
 }
 
+/// When ECH is disabled in the network config, ECH configs from HTTPS records
+/// are ignored: endpoints get `ech_config: None` and the origin fallback is
+/// not skipped.
+///
+/// HTTPS record has ECH + H3 ALPN with v6 hints. AAAA positive for origin.
+/// With ECH disabled:
+///   - HTTPS bucket uses hints: V6:H3 (no ECH)
+///   - Origin fallback is NOT skipped: V6:H2OrH1
+///
+/// <https://github.com/mozilla/happy-eyeballs/issues/20>
+#[test]
+fn ech_disabled() {
+    let (mut now, mut he) = setup_with_config(NetworkConfig {
+        ech: false,
+        ..NetworkConfig::default()
+    });
+
+    he.expect(
+        vec![
+            (None, Some(out_send_dns_https(Id::from(0)))),
+            (None, Some(out_send_dns_aaaa(Id::from(1)))),
+            (None, Some(out_send_dns_a(Id::from(2)))),
+            (
+                Some(in_dns_a_negative(Id::from(2))),
+                Some(out_resolution_delay()),
+            ),
+            (
+                Some(in_dns_aaaa_positive(Id::from(1))),
+                Some(out_resolution_delay()),
+            ),
+            (
+                Some(Input::DnsResult {
+                    id: Id::from(0),
+                    result: DnsResult::Https(Ok(vec![ServiceInfo {
+                        priority: 1,
+                        target_name: HOSTNAME.into(),
+                        // Only H3 in ALPN — fallback bucket uses H2OrH1 by default.
+                        alpn_http_versions: HashSet::from([HttpVersion::H3]),
+                        ipv6_hints: vec![V6_ADDR],
+                        ipv4_hints: vec![],
+                        ech_config: Some(ECH_CONFIG.to_vec()),
+                        port: None,
+                    }])),
+                }),
+                // HTTPS bucket: V6:H3, but ECH stripped.
+                Some(Output::AttemptConnection {
+                    id: Id::from(3),
+                    endpoint: Endpoint {
+                        address: SocketAddr::new(V6_ADDR.into(), PORT),
+                        http_version: ConnectionAttemptHttpVersions::H3,
+                        ech_config: None,
+                    },
+                }),
+            ),
+        ],
+        now,
+    );
+
+    // Origin fallback is NOT skipped despite HTTPS record having ECH.
+    he.expect_connection_attempts(
+        &mut now,
+        vec![Output::AttemptConnection {
+            id: Id::from(4),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H2OrH1,
+                ech_config: None,
+            },
+        }],
+    );
+}
+
 #[test]
 fn ech_config_from_https_applies_to_aaaa() {
     let (now, mut he) = setup();


### PR DESCRIPTION
Add `NetworkConfig::ech` flag (default `true`). When set to `false`, `any_ech()` always returns false — disabling ECH-based filtering of ServiceInfos and origin fallback — and `flatten_into_endpoints` strips ECH configs from endpoints.

Fixes #20.