### PR TITLE
Ignore EchRetry when ECH was not sent on the attempt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1026,6 +1026,11 @@ impl HappyEyeballs {
                     return;
                 }
 
+                if attempt.endpoint.ech_config.is_none() {
+                    debug_assert!(false, "got EchRetry on attempt {id:?} but ECH was not sent");
+                    return;
+                }
+
                 // > Clients SHOULD NOT accept "retry_config" in response
                 // > to a connection initiated in response to a
                 // > "retry_config".


### PR DESCRIPTION
If a server returns retry_configs but the client never sent ECH on that connection attempt, accepting the retry would be nonsensical. Guard against this with a debug_assert to surface the invariant violation in debug builds while ignoring it gracefully in release builds.

Follow-up to https://github.com/mozilla/happy-eyeballs/pull/55#discussion_r2996074498.