### PR TITLE
Discard HTTPS RR address hints on negative A/AAAA answer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,8 +302,12 @@ impl ServiceInfo {
     fn flatten_into_endpoints(
         &self,
         port: u16,
-        ipv4_addrs: &[Ipv4Addr],
-        ipv6_addrs: &[Ipv6Addr],
+        // `None` if no A response has been received yet; `Some(addrs)` once
+        // an answer (positive or negative) has arrived.
+        ipv4_addrs: Option<&[Ipv4Addr]>,
+        // `None` if no AAAA response has been received yet; `Some(addrs)`
+        // once an answer (positive or negative) has arrived.
+        ipv6_addrs: Option<&[Ipv6Addr]>,
         http_versions: &HashSet<ConnectionAttemptHttpVersions>,
         ech_enabled: bool,
     ) -> Vec<Endpoint> {
@@ -316,15 +320,17 @@ impl ServiceInfo {
         // > are not available yet.
         //
         // <https://www.ietf.org/archive/id/draft-ietf-happy-happyeyeballs-v3-02.html#section-4.2.1>
-        let hint_v6 = if ipv6_addrs.is_empty() {
-            self.ipv6_hints.as_slice()
-        } else {
-            &[]
+        //
+        // Once an answer arrives — positive or negative — the records are no
+        // longer "not available yet". A positive answer replaces hints with
+        // actual addresses; a negative answer discards them entirely.
+        let hint_v6 = match ipv6_addrs {
+            None => self.ipv6_hints.as_slice(),
+            Some(_) => &[],
         };
-        let hint_v4 = if ipv4_addrs.is_empty() {
-            self.ipv4_hints.as_slice()
-        } else {
-            &[]
+        let hint_v4 = match ipv4_addrs {
+            None => self.ipv4_hints.as_slice(),
+            Some(_) => &[],
         };
 
         let hint_http_versions: HashSet<ConnectionAttemptHttpVersions> =
@@ -351,10 +357,11 @@ impl ServiceInfo {
             });
 
         let addrs = ipv6_addrs
+            .unwrap_or(&[])
             .iter()
             .cloned()
             .map(IpAddr::V6)
-            .chain(ipv4_addrs.iter().cloned().map(IpAddr::V4))
+            .chain(ipv4_addrs.unwrap_or(&[]).iter().cloned().map(IpAddr::V4))
             .flat_map(|ip| {
                 // TODO: way around allocation?
                 let ech_config = ech_enabled.then(|| self.ech_config.clone()).flatten();
@@ -1196,36 +1203,30 @@ impl HappyEyeballs {
         let http_versions = self.https_record_http_versions();
         let mut endpoints: Vec<Endpoint> = Vec::new();
         for info in &service_infos {
-            let ipv4_addrs: Vec<Ipv4Addr> = self
-                .dns_queries
-                .iter()
-                .filter_map(|q| match &q.state {
+            let ipv4_addrs: Option<&[Ipv4Addr]> =
+                self.dns_queries.iter().find_map(|q| match &q.state {
                     DnsQueryState::Completed {
-                        response: DnsResult::A(Ok(addrs)),
+                        response: DnsResult::A(result),
                         ..
-                    } if q.target_name == info.target_name => Some(addrs.as_slice()),
+                    } if q.target_name == info.target_name => {
+                        Some(result.as_deref().unwrap_or_default())
+                    }
                     _ => None,
-                })
-                .flatten()
-                .cloned()
-                .collect();
-            let ipv6_addrs: Vec<Ipv6Addr> = self
-                .dns_queries
-                .iter()
-                .filter_map(|q| match &q.state {
+                });
+            let ipv6_addrs: Option<&[Ipv6Addr]> =
+                self.dns_queries.iter().find_map(|q| match &q.state {
                     DnsQueryState::Completed {
-                        response: DnsResult::Aaaa(Ok(addrs)),
+                        response: DnsResult::Aaaa(result),
                         ..
-                    } if q.target_name == info.target_name => Some(addrs.as_slice()),
+                    } if q.target_name == info.target_name => {
+                        Some(result.as_deref().unwrap_or_default())
+                    }
                     _ => None,
-                })
-                .flatten()
-                .cloned()
-                .collect();
+                });
             let mut bucket = info.flatten_into_endpoints(
                 self.port,
-                &ipv4_addrs,
-                &ipv6_addrs,
+                ipv4_addrs,
+                ipv6_addrs,
                 &http_versions,
                 self.network_config.ech,
             );

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -74,6 +74,21 @@ pub fn in_dns_https_positive(id: Id) -> Input {
     }
 }
 
+pub fn in_dns_https_positive_ech(id: Id) -> Input {
+    Input::DnsResult {
+        id,
+        result: DnsResult::Https(Ok(vec![ServiceInfo {
+            priority: 1,
+            target_name: HOSTNAME.into(),
+            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+            ipv6_hints: vec![],
+            ipv4_hints: vec![],
+            ech_config: Some(ech_config()),
+            port: None,
+        }])),
+    }
+}
+
 pub fn in_dns_https_positive_no_alpn(id: Id) -> Input {
     Input::DnsResult {
         id,
@@ -110,6 +125,10 @@ pub fn in_dns_https_positive_v6_hints(id: Id) -> Input {
 
 pub fn in_dns_https_positive_v4_hints(id: Id) -> Input {
     in_dns_https_with_hints(id, vec![V4_ADDR], vec![])
+}
+
+pub fn in_dns_https_positive_v4_and_v6_hints(id: Id) -> Input {
+    in_dns_https_with_hints(id, vec![V4_ADDR], vec![V6_ADDR])
 }
 
 pub fn in_dns_https_positive_svc1(id: Id) -> Input {

--- a/tests/hostname_resolution.rs
+++ b/tests/hostname_resolution.rs
@@ -11,7 +11,8 @@ use std::{
 
 use happy_eyeballs::{
     CONNECTION_ATTEMPT_DELAY, ConnectionAttemptHttpVersions, DnsRecordType, DnsResult, Endpoint,
-    HappyEyeballs, HttpVersions, Id, Input, IpPreference, NetworkConfig, Output, RESOLUTION_DELAY,
+    FailureReason, HappyEyeballs, HttpVersions, Id, Input, IpPreference, NetworkConfig, Output,
+    RESOLUTION_DELAY,
 };
 
 fn expect_hints_move_on_with_timeout(
@@ -316,10 +317,17 @@ fn resolution_delay_starts_on_first_response() {
 /// > algorithm when A and AAAA records corresponding to the TargetName
 /// > are not available yet.
 ///
+/// HTTPS arrives first with both v6 and v4 hints while AAAA and A are still
+/// in-flight. After the resolution timeout the v6 hint is used. When AAAA
+/// and A subsequently arrive with negative answers, both hints are discarded
+/// — a negative answer replaces hints per the draft: "when those records are
+/// received, they replace the hints". After the in-flight v6 attempt fails,
+/// no v4 attempt follows (v4 hint was discarded when A returned negative).
+///
 /// <https://www.ietf.org/archive/id/draft-ietf-happy-happyeyeballs-v3-02.html#section-4.2.1>
 #[test]
 fn https_hints() {
-    let (now, mut he) = setup();
+    let (mut now, mut he) = setup();
 
     he.expect(
         vec![
@@ -327,16 +335,34 @@ fn https_hints() {
             (None, Some(out_send_dns_aaaa(Id::from(1)))),
             (None, Some(out_send_dns_a(Id::from(2)))),
             (
-                Some(in_dns_aaaa_negative(Id::from(1))),
+                Some(in_dns_https_positive_v4_and_v6_hints(Id::from(0))),
                 Some(out_resolution_delay()),
+            ),
+        ],
+        now,
+    );
+
+    now += RESOLUTION_DELAY;
+    he.expect(
+        vec![
+            (None, Some(out_attempt_v6_h3(Id::from(3)))),
+            (None, Some(out_connection_attempt_delay())),
+            // AAAA and A arrive negative: both hints are discarded. The
+            // connection attempt delay is re-emitted while the in-flight
+            // v6 attempt is still pending.
+            (
+                Some(in_dns_aaaa_negative(Id::from(1))),
+                Some(out_connection_attempt_delay()),
             ),
             (
                 Some(in_dns_a_negative(Id::from(2))),
-                Some(out_resolution_delay()),
+                Some(out_connection_attempt_delay()),
             ),
+            // The v6 attempt fails. No v4 retry — v4 hint was discarded when
+            // A returned a negative answer.
             (
-                Some(in_dns_https_positive_v6_hints(Id::from(0))),
-                Some(out_attempt_v6_h3(Id::from(3))),
+                Some(in_connection_result_negative(Id::from(3))),
+                Some(Output::Failed(FailureReason::Connection)),
             ),
         ],
         now,

--- a/tests/https_records.rs
+++ b/tests/https_records.rs
@@ -5,32 +5,27 @@ use common::*;
 
 use std::{
     collections::HashSet,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
 };
 
 use happy_eyeballs::{
     AltSvc, CONNECTION_ATTEMPT_DELAY, ConnectionAttemptHttpVersions, ConnectionResult,
     DnsRecordType, DnsResult, EchConfig, Endpoint, FailureReason, HttpVersion, Id, Input,
-    NetworkConfig, Output, ServiceInfo,
+    IpPreference, NetworkConfig, Output, RESOLUTION_DELAY, ServiceInfo,
 };
 
 #[test]
 fn ech_config_propagated_to_endpoint() {
-    let (now, mut he) = setup();
+    let (mut now, mut he) = setup();
 
+    // HTTPS arrives with an ECH config and a v6 hint while AAAA and A are
+    // still in-flight. After the resolution delay the hint is used, and the
+    // ECH config must be carried onto the endpoint.
     he.expect(
         vec![
             (None, Some(out_send_dns_https(Id::from(0)))),
             (None, Some(out_send_dns_aaaa(Id::from(1)))),
             (None, Some(out_send_dns_a(Id::from(2)))),
-            (
-                Some(in_dns_aaaa_negative(Id::from(1))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_a_negative(Id::from(2))),
-                Some(out_resolution_delay()),
-            ),
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
@@ -44,18 +39,110 @@ fn ech_config_propagated_to_endpoint() {
                         port: None,
                     }])),
                 }),
-                Some(Output::AttemptConnection {
-                    id: Id::from(3),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H3,
-                        ech_config: Some(ech_config()),
-                    },
-                }),
+                Some(out_resolution_delay()),
             ),
         ],
         now,
     );
+
+    now += RESOLUTION_DELAY;
+    he.expect(
+        vec![(
+            None,
+            Some(Output::AttemptConnection {
+                id: Id::from(3),
+                endpoint: Endpoint {
+                    address: SocketAddr::new(V6_ADDR.into(), PORT),
+                    http_version: ConnectionAttemptHttpVersions::H3,
+                    ech_config: Some(ech_config()),
+                },
+            }),
+        )],
+        now,
+    );
+}
+
+/// HTTPS RR address hints must be discarded when the corresponding address
+/// family returns a negative answer. Per the Happy Eyeballs v3 draft, hints
+/// apply only "when A and AAAA records are not available yet"; a negative
+/// answer replaces them.
+///
+/// Tested for both preferences (prefer-V6 with AAAA negative, prefer-V4 with
+/// A negative) to verify symmetry.
+#[test]
+fn hints_discarded_on_negative_answer() {
+    struct Case {
+        config: NetworkConfig,
+        /// Non-preferred family, returns positive — arrives first.
+        first_arrives: Input,
+        /// Preferred family, returns negative — arrives second.
+        second_arrives: Input,
+        ipv6_hints: Vec<Ipv6Addr>,
+        ipv4_hints: Vec<Ipv4Addr>,
+        attempt_1: Output,
+        attempt_2: Output,
+        attempt_3: Output, // origin fallback
+    }
+
+    let cases = vec![
+        // Prefer V6: AAAA negative, A positive — V6 hint must be discarded.
+        Case {
+            config: NetworkConfig::default(),
+            first_arrives: in_dns_a_positive(Id::from(2)),
+            second_arrives: in_dns_aaaa_negative(Id::from(1)),
+            ipv6_hints: vec![V6_ADDR],
+            ipv4_hints: vec![],
+            attempt_1: out_attempt_v4_h3(Id::from(3)),
+            attempt_2: out_attempt_v4_h2(Id::from(4)),
+            attempt_3: out_attempt_v4_h1_h2(Id::from(5)),
+        },
+        // Prefer V4: A negative, AAAA positive — V4 hint must be discarded.
+        Case {
+            config: NetworkConfig {
+                ip: IpPreference::DualStackPreferV4,
+                ..NetworkConfig::default()
+            },
+            first_arrives: in_dns_aaaa_positive(Id::from(1)),
+            second_arrives: in_dns_a_negative(Id::from(2)),
+            ipv6_hints: vec![],
+            ipv4_hints: vec![V4_ADDR],
+            attempt_1: out_attempt_v6_h3(Id::from(3)),
+            attempt_2: out_attempt_v6_h2(Id::from(4)),
+            attempt_3: out_attempt_v6_h1_h2(Id::from(5)),
+        },
+    ];
+
+    for case in cases {
+        let (mut now, mut he) = setup_with_config(case.config);
+
+        he.expect(
+            vec![
+                (None, Some(out_send_dns_https(Id::from(0)))),
+                (None, Some(out_send_dns_aaaa(Id::from(1)))),
+                (None, Some(out_send_dns_a(Id::from(2)))),
+                (Some(case.first_arrives), Some(out_resolution_delay())),
+                (Some(case.second_arrives), Some(out_resolution_delay())),
+                (
+                    Some(Input::DnsResult {
+                        id: Id::from(0),
+                        result: DnsResult::Https(Ok(vec![ServiceInfo {
+                            priority: 1,
+                            target_name: HOSTNAME.into(),
+                            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+                            ipv6_hints: case.ipv6_hints,
+                            ipv4_hints: case.ipv4_hints,
+                            ech_config: None,
+                            port: None,
+                        }])),
+                    }),
+                    Some(case.attempt_1),
+                ),
+            ],
+            now,
+        );
+
+        he.expect_connection_attempts(&mut now, vec![case.attempt_2, case.attempt_3]);
+    }
 }
 
 /// When ECH is disabled in the network config, ECH configs from HTTPS records
@@ -627,23 +714,16 @@ mod https_port_svcparam_overrides_port_for {
     use super::*;
 
     fn check(ipv4_hints: Vec<Ipv4Addr>) {
-        let (now, mut he) = setup(); // constructed with PORT (443)
+        let (mut now, mut he) = setup(); // constructed with PORT (443)
 
+        // HTTPS arrives with port=8443 while AAAA and A are still in-flight.
+        // After the resolution delay the hint is used; the connection attempt
+        // must use 8443, not the authority port 443. IPv6 is preferred.
         he.expect(
             vec![
                 (None, Some(out_send_dns_https(Id::from(0)))),
                 (None, Some(out_send_dns_aaaa(Id::from(1)))),
                 (None, Some(out_send_dns_a(Id::from(2)))),
-                (
-                    Some(in_dns_aaaa_negative(Id::from(1))),
-                    Some(out_resolution_delay()),
-                ),
-                (
-                    Some(in_dns_a_negative(Id::from(2))),
-                    Some(out_resolution_delay()),
-                ),
-                // HTTPS record carries port=8443; the connection attempt must use
-                // 8443, not the authority port 443. IPv6 is preferred.
                 (
                     Some(Input::DnsResult {
                         id: Id::from(0),
@@ -657,9 +737,15 @@ mod https_port_svcparam_overrides_port_for {
                             port: Some(CUSTOM_PORT),
                         }])),
                     }),
-                    Some(out_attempt_v6_h3_custom_port(Id::from(3))),
+                    Some(out_resolution_delay()),
                 ),
             ],
+            now,
+        );
+
+        now += RESOLUTION_DELAY;
+        he.expect(
+            vec![(None, Some(out_attempt_v6_h3_custom_port(Id::from(3))))],
             now,
         );
     }

--- a/tests/type_impls.rs
+++ b/tests/type_impls.rs
@@ -1,7 +1,9 @@
 mod common;
 use common::*;
 
-use happy_eyeballs::{HappyEyeballs, HttpVersion, Id, ServiceInfo, TargetName};
+use happy_eyeballs::{
+    ConnectionResult, EchConfig, HttpVersion, Id, Input, ServiceInfo, TargetName,
+};
 
 #[test]
 fn id_roundtrip() {
@@ -68,17 +70,42 @@ fn happy_eyeballs_debug() {
     let s = format!("{he:?}");
     assert!(s.contains("dns_queries"), "missing 'dns_queries': {s}");
 
-    // IP host: first process_output immediately starts a connection.
-    let mut he_ip = HappyEyeballs::new(&format!("[{V6_ADDR}]"), PORT).unwrap();
-    let _ = he_ip.process_output(now);
-    let s = format!("{he_ip:?}");
+    // Set up a hostname-based HE with an HTTPS record that provides ECH
+    // config, so the connection attempt carries ECH and EchRetry is valid.
+    let (now2, mut he2) = setup();
+
+    // Drive through DNS queries, feed HTTPS+ECH and AAAA to get a connection
+    // attempt that carries ECH config.
+    he2.expect(
+        vec![
+            (None, Some(out_send_dns_https(Id::from(0)))),
+            (None, Some(out_send_dns_aaaa(Id::from(1)))),
+            (None, Some(out_send_dns_a(Id::from(2)))),
+            (
+                Some(in_dns_https_positive_ech(Id::from(0))),
+                Some(out_resolution_delay()),
+            ),
+        ],
+        now2,
+    );
+
+    // AAAA arrives; connection attempt with ECH is emitted.
+    he2.process_input(in_dns_aaaa_positive(Id::from(1)), now2);
+    let _ = he2.process_output(now2);
+    let s = format!("{he2:?}");
     assert!(
         s.contains("connection_attempts"),
         "missing 'connection_attempts': {s}"
     );
 
     // Feed EchRetry for the in-progress connection to populate ech_retries.
-    he_ip.process_input(in_connection_result_ech_retry(Id::from(0)), now);
-    let s = format!("{he_ip:?}");
+    he2.process_input(
+        Input::ConnectionResult {
+            id: Id::from(3),
+            result: ConnectionResult::EchRetry(EchConfig::new(vec![10, 20, 30])),
+        },
+        now2,
+    );
+    let s = format!("{he2:?}");
     assert!(s.contains("ech_retries"), "missing 'ech_retries': {s}");
 }


### PR DESCRIPTION
The draft says hints apply "when A and AAAA records corresponding to the TargetName are not available yet". A negative answer means the records *are* available (with no addresses), so hints must be discarded.

Previously `flatten_into_endpoints()` used hints whenever the resolved address slice was empty, which was true for both "not yet received" and "received negative". Change the parameter types from `&[T]` to `Option<&[T]>` (`None` = in-flight, `Some` = answered) so the two cases are distinguishable.

Fixes https://github.com/mozilla/happy-eyeballs/issues/64.

//CC @acreskeyMoz