### PR TITLE
chore: Slay the mutants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1464,3 +1464,36 @@ impl HappyEyeballs {
             .any(|completed| now.duration_since(*completed) >= self.network_config.resolution_delay)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use super::*;
+
+    #[test]
+    fn dns_result_has_addrs() {
+        for result in [
+            DnsResult::Aaaa(Ok(vec![])),
+            DnsResult::Aaaa(Err(())),
+            DnsResult::A(Ok(vec![])),
+            DnsResult::A(Err(())),
+            DnsResult::Https(Err(())),
+            DnsResult::Https(Ok(vec![])),
+        ] {
+            assert!(!result.has_addrs());
+        }
+        assert!(DnsResult::Aaaa(Ok(vec![Ipv6Addr::LOCALHOST])).has_addrs());
+        assert!(DnsResult::A(Ok(vec![Ipv4Addr::LOCALHOST])).has_addrs());
+    }
+
+    #[test]
+    fn host_display() {
+        let v4 = Ipv4Addr::LOCALHOST;
+        assert_eq!(Host::Ip(v4.into()).to_string(), v4.to_string());
+        let v6 = Ipv6Addr::LOCALHOST;
+        assert_eq!(Host::Ip(v6.into()).to_string(), v6.to_string());
+        let domain = "example.com";
+        assert_eq!(Host::Domain(domain.into()).to_string(), domain);
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -89,19 +89,27 @@ pub fn in_dns_https_positive_no_alpn(id: Id) -> Input {
     }
 }
 
-pub fn in_dns_https_positive_v6_hints(id: Id) -> Input {
+fn in_dns_https_with_hints(id: Id, ipv4_hints: Vec<Ipv4Addr>, ipv6_hints: Vec<Ipv6Addr>) -> Input {
     Input::DnsResult {
         id,
         result: DnsResult::Https(Ok(vec![ServiceInfo {
             priority: 1,
             target_name: HOSTNAME.into(),
             alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-            ipv6_hints: vec![V6_ADDR],
-            ipv4_hints: vec![],
+            ipv4_hints,
+            ipv6_hints,
             ech_config: None,
             port: None,
         }])),
     }
+}
+
+pub fn in_dns_https_positive_v6_hints(id: Id) -> Input {
+    in_dns_https_with_hints(id, vec![], vec![V6_ADDR])
+}
+
+pub fn in_dns_https_positive_v4_hints(id: Id) -> Input {
+    in_dns_https_with_hints(id, vec![V4_ADDR], vec![])
 }
 
 pub fn in_dns_https_positive_svc1(id: Id) -> Input {
@@ -165,6 +173,13 @@ pub fn in_connection_result_negative(id: Id) -> Input {
     Input::ConnectionResult {
         id,
         result: ConnectionResult::Failure("connection refused".to_string()),
+    }
+}
+
+pub fn in_connection_result_ech_retry(id: Id) -> Input {
+    Input::ConnectionResult {
+        id,
+        result: ConnectionResult::EchRetry(ech_config()),
     }
 }
 

--- a/tests/connection_attempts.rs
+++ b/tests/connection_attempts.rs
@@ -4,10 +4,11 @@
 mod common;
 use common::*;
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 use happy_eyeballs::{
-    CONNECTION_ATTEMPT_DELAY, ConnectionAttemptHttpVersions, DnsResult, Endpoint, Id, Input, Output,
+    CONNECTION_ATTEMPT_DELAY, ConnectionAttemptHttpVersions, DnsResult, Endpoint, Id, Input,
+    NetworkConfig, Output,
 };
 
 #[test]
@@ -251,6 +252,46 @@ fn succeeded_keeps_emitting_succeeded() {
             (None, Some(Output::Succeeded)),
         ],
         now,
+    );
+}
+
+/// The connection-attempt-delay timer reflects the time *remaining*, not the full delay.
+/// Calling process_output partway through the delay should return a timer for the remainder.
+#[test]
+fn connection_attempt_delay_partial_elapsed() {
+    let custom_delay = Duration::from_millis(100);
+    let (now, mut he) = setup_with_config(NetworkConfig {
+        connection_attempt_delay: custom_delay,
+        ..NetworkConfig::default()
+    });
+
+    // Drive to first connection attempt at time T=now.
+    he.expect(
+        vec![
+            (None, Some(out_send_dns_https(Id::from(0)))),
+            (None, Some(out_send_dns_aaaa(Id::from(1)))),
+            (None, Some(out_send_dns_a(Id::from(2)))),
+            (
+                Some(in_dns_https_negative(Id::from(0))),
+                Some(out_resolution_delay()),
+            ),
+            (
+                Some(in_dns_aaaa_positive(Id::from(1))),
+                Some(out_attempt_v6_h1_h2(Id::from(3))),
+            ),
+        ],
+        now,
+    );
+
+    let elapsed = Duration::from_millis(40);
+    he.expect(
+        vec![(
+            None,
+            Some(Output::Timer {
+                duration: custom_delay - elapsed,
+            }),
+        )],
+        now + elapsed,
     );
 }
 

--- a/tests/hostname_resolution.rs
+++ b/tests/hostname_resolution.rs
@@ -4,12 +4,34 @@
 mod common;
 use common::*;
 
-use std::{net::SocketAddr, time::Duration};
+use std::{
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
 
 use happy_eyeballs::{
     CONNECTION_ATTEMPT_DELAY, ConnectionAttemptHttpVersions, DnsRecordType, DnsResult, Endpoint,
-    HttpVersions, Id, Input, IpPreference, NetworkConfig, Output, RESOLUTION_DELAY,
+    HappyEyeballs, HttpVersions, Id, Input, IpPreference, NetworkConfig, Output, RESOLUTION_DELAY,
 };
+
+fn expect_hints_move_on_with_timeout(
+    he: &mut HappyEyeballs,
+    now: &mut Instant,
+    https_input: Input,
+    expected_attempt: Output,
+) {
+    he.expect(
+        vec![
+            (None, Some(out_send_dns_https(Id::from(0)))),
+            (None, Some(out_send_dns_aaaa(Id::from(1)))),
+            (None, Some(out_send_dns_a(Id::from(2)))),
+            (Some(https_input), Some(out_resolution_delay())),
+        ],
+        *now,
+    );
+    *now += RESOLUTION_DELAY;
+    he.expect(vec![(None, Some(expected_attempt))], *now);
+}
 
 #[test]
 fn initial_state() {
@@ -331,14 +353,46 @@ fn https_hints() {
 #[test]
 fn https_hints_move_on_with_timeout() {
     let (mut now, mut he) = setup();
+    expect_hints_move_on_with_timeout(
+        &mut he,
+        &mut now,
+        in_dns_https_positive_v6_hints(Id::from(0)),
+        out_attempt_v6_h3(Id::from(3)),
+    );
+}
+
+/// HTTPS IPv4 hints should also count for `move_on_with_timeout`.
+///
+/// Mirrors `https_hints_move_on_with_timeout` but using IPv4 hints instead of IPv6.
+#[test]
+fn https_v4_hints_move_on_with_timeout() {
+    let (mut now, mut he) = setup();
+    expect_hints_move_on_with_timeout(
+        &mut he,
+        &mut now,
+        in_dns_https_positive_v4_hints(Id::from(0)),
+        out_attempt_v4_h3(Id::from(3)),
+    );
+}
+
+/// When the resolution delay has exactly elapsed, `process_output` returns `None`,
+/// not a zero-duration timer.
+#[test]
+fn resolution_delay_boundary() {
+    let (mut now, mut he) = setup();
 
     he.expect(
         vec![
             (None, Some(out_send_dns_https(Id::from(0)))),
             (None, Some(out_send_dns_aaaa(Id::from(1)))),
             (None, Some(out_send_dns_a(Id::from(2)))),
+            // HTTPS negative and A positive arrive at T; AAAA still pending.
             (
-                Some(in_dns_https_positive_v6_hints(Id::from(0))),
+                Some(in_dns_https_negative(Id::from(0))),
+                Some(out_resolution_delay()),
+            ),
+            (
+                Some(in_dns_a_positive(Id::from(2))),
                 Some(out_resolution_delay()),
             ),
         ],
@@ -347,7 +401,15 @@ fn https_hints_move_on_with_timeout() {
 
     now += RESOLUTION_DELAY;
 
-    he.expect(vec![(None, Some(out_attempt_v6_h3(Id::from(3))))], now);
+    // Resolution delay has elapsed; move_on_with_timeout fires.
+    he.expect(vec![(None, Some(out_attempt_v4_h1_h2(Id::from(3))))], now);
+
+    // Connection fails immediately. AAAA still pending, resolution delay exactly
+    // expired — no timer, just None.
+    he.expect(
+        vec![(Some(in_connection_result_negative(Id::from(3))), None)],
+        now,
+    );
 }
 
 /// > Note that clients are still required to issue A and AAAA queries

--- a/tests/network_config.rs
+++ b/tests/network_config.rs
@@ -4,8 +4,8 @@ use common::*;
 use std::time::{Duration, Instant};
 
 use happy_eyeballs::{
-    AltSvc, ConnectionAttemptHttpVersions, FailureReason, HappyEyeballs, HttpVersion, Id,
-    NetworkConfig, Output,
+    AltSvc, ConnectionAttemptHttpVersions, FailureReason, HappyEyeballs, HttpVersion, HttpVersions,
+    Id, NetworkConfig, Output,
 };
 
 #[test]
@@ -257,4 +257,68 @@ fn custom_delays() {
         ],
         now,
     );
+}
+
+/// Config with `version` disabled in `http_versions` and present as the sole alt-svc entry.
+fn alt_svc_disabled_config(version: HttpVersion) -> NetworkConfig {
+    let http_versions = match version {
+        HttpVersion::H3 => HttpVersions {
+            h3: false,
+            ..Default::default()
+        },
+        HttpVersion::H2 => HttpVersions {
+            h2: false,
+            ..Default::default()
+        },
+        HttpVersion::H1 => HttpVersions {
+            h1: false,
+            ..Default::default()
+        },
+    };
+    NetworkConfig {
+        http_versions,
+        alt_svc: vec![AltSvc {
+            host: None,
+            port: None,
+            http_version: version,
+        }],
+        ..NetworkConfig::default()
+    }
+}
+
+fn assert_alt_svc_version_disabled(
+    version: HttpVersion,
+    expected_fallback: ConnectionAttemptHttpVersions,
+) {
+    let now = Instant::now();
+    let mut he = HappyEyeballs::new_with_network_config(
+        &V4_ADDR.to_string(),
+        PORT,
+        alt_svc_disabled_config(version),
+    )
+    .unwrap();
+    he.expect(
+        vec![(
+            None,
+            Some(out_attempt(
+                Id::from(0),
+                V4_ADDR.into(),
+                PORT,
+                expected_fallback,
+            )),
+        )],
+        now,
+    );
+}
+
+/// Alt-svc H2 entry is filtered out when H2 is disabled in the network config.
+#[test]
+fn alt_svc_h2_disabled() {
+    assert_alt_svc_version_disabled(HttpVersion::H2, ConnectionAttemptHttpVersions::H1);
+}
+
+/// Alt-svc H1 entry is filtered out when H1 is disabled in the network config.
+#[test]
+fn alt_svc_h1_disabled() {
+    assert_alt_svc_version_disabled(HttpVersion::H1, ConnectionAttemptHttpVersions::H2);
 }

--- a/tests/type_impls.rs
+++ b/tests/type_impls.rs
@@ -1,0 +1,84 @@
+mod common;
+use common::*;
+
+use happy_eyeballs::{HappyEyeballs, HttpVersion, Id, ServiceInfo, TargetName};
+
+#[test]
+fn id_roundtrip() {
+    for n in [0u64, 42] {
+        assert_eq!(u64::from(Id::from(n)), n);
+    }
+}
+
+#[test]
+fn ech_config_as_ref() {
+    assert_eq!(ech_config().as_ref(), ECH_CONFIG_BYTES);
+}
+
+#[test]
+fn target_name_conversions() {
+    let name = TargetName::from(HOSTNAME);
+    assert_eq!(format!("{name:?}"), HOSTNAME);
+    assert_eq!(String::from(name), HOSTNAME);
+}
+
+#[test]
+fn service_info_debug() {
+    // With optional fields populated: all conditional fields must appear.
+    let full = ServiceInfo {
+        priority: 1,
+        target_name: HOSTNAME.into(),
+        alpn_http_versions: [HttpVersion::H3].into(),
+        ech_config: Some(ech_config()),
+        ipv4_hints: vec![V4_ADDR],
+        ipv6_hints: vec![V6_ADDR],
+        port: None,
+    };
+    let s = format!("{full:?}");
+    assert!(s.contains("alpn"), "missing 'alpn': {s}");
+    assert!(s.contains("ipv4"), "missing 'ipv4': {s}");
+    assert!(s.contains("ipv6"), "missing 'ipv6': {s}");
+
+    // With optional fields empty: conditional fields must not appear.
+    let bare = ServiceInfo {
+        alpn_http_versions: Default::default(),
+        ech_config: None,
+        ipv4_hints: vec![],
+        ipv6_hints: vec![],
+        ..full
+    };
+    let s = format!("{bare:?}");
+    assert!(!s.contains("alpn"), "unexpected 'alpn': {s}");
+    assert!(!s.contains("ipv4"), "unexpected 'ipv4': {s}");
+    assert!(!s.contains("ipv6"), "unexpected 'ipv6': {s}");
+}
+
+#[test]
+fn happy_eyeballs_debug() {
+    let (now, mut he) = setup();
+
+    // Fresh domain host: always has "target" and "port", never "dns_queries" yet.
+    let s = format!("{he:?}");
+    assert!(s.contains("target"), "missing 'target': {s}");
+    assert!(s.contains("port"), "missing 'port': {s}");
+    assert!(!s.contains("dns_queries"), "unexpected 'dns_queries': {s}");
+
+    // After first process_output, dns_queries is populated.
+    let _ = he.process_output(now);
+    let s = format!("{he:?}");
+    assert!(s.contains("dns_queries"), "missing 'dns_queries': {s}");
+
+    // IP host: first process_output immediately starts a connection.
+    let mut he_ip = HappyEyeballs::new(&format!("[{V6_ADDR}]"), PORT).unwrap();
+    let _ = he_ip.process_output(now);
+    let s = format!("{he_ip:?}");
+    assert!(
+        s.contains("connection_attempts"),
+        "missing 'connection_attempts': {s}"
+    );
+
+    // Feed EchRetry for the in-progress connection to populate ech_retries.
+    he_ip.process_input(in_connection_result_ech_retry(Id::from(0)), now);
+    let s = format!("{he_ip:?}");
+    assert!(s.contains("ech_retries"), "missing 'ech_retries': {s}");
+}


### PR DESCRIPTION
This should get the code to zero mutants, meaning we *could* think about requiring the `mutants` workflow to pass for PRs...