### PR TITLE
fix: grant discussions:read to Claude review workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,6 +21,7 @@ jobs:
       pull-requests: write # post review comments
       issues: read # read issue context for review
       actions: read # read workflow run context
+      discussions: read # read discussion context for review
     uses: mozilla/actions/.github/workflows/claude-review.yml@27cbe8fb5d338c2861b787e5de10410559065db1 # v1.1.3
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
The
   \`claude-review\` reusable workflow from \`mozilla/actions\` uses GitHub Discussions MCP tools and requires \`discussions: read\`. Without it,
   GitHub raises a \`startup_failure\` before any jobs run.