### PR TITLE
Surface `is_ech_retry` through `Output::AttemptConnection`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "happy-eyeballs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "happy-eyeballs"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ while let Some(output) = he.process_output(now) {
         Output::SendDnsQuery { id, hostname, record_type } => {
             // Send DNS query.
         }
-        Output::AttemptConnection { id, endpoint } => {
+        Output::AttemptConnection { id, endpoint, is_ech_retry } => {
             // Attempt connection.
         }
         _ => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!             // Send DNS query.
 //! #           dns_id = Some(id);
 //!         }
-//!         Output::AttemptConnection { id, endpoint } => {
+//!         Output::AttemptConnection { id, endpoint, is_ech_retry } => {
 //!             // Attempt connection.
 //!         }
 //!         _ => {}
@@ -219,8 +219,16 @@ pub enum Output {
     /// Start a timer
     Timer { duration: Duration },
 
-    /// Attempt to connect to an address
-    AttemptConnection { id: Id, endpoint: Endpoint },
+    /// Attempt to connect to an address.
+    ///
+    /// `is_ech_retry` is `true` iff this attempt was scheduled in response to
+    /// a [`ConnectionResult::EchRetry`] on a prior attempt (i.e. an in-band
+    /// ECH configuration update).
+    AttemptConnection {
+        id: Id,
+        endpoint: Endpoint,
+        is_ech_retry: bool,
+    },
 
     /// Cancel a connection attempt
     CancelConnection { id: Id },
@@ -1127,7 +1135,11 @@ impl HappyEyeballs {
             is_ech_retry: false,
         });
 
-        Some(Output::AttemptConnection { id, endpoint })
+        Some(Output::AttemptConnection {
+            id,
+            endpoint,
+            is_ech_retry: false,
+        })
     }
 
     /// Emit a connection attempt for a pending ECH retry, if any.
@@ -1154,7 +1166,11 @@ impl HappyEyeballs {
             is_ech_retry: true,
         });
 
-        Some(Output::AttemptConnection { id, endpoint })
+        Some(Output::AttemptConnection {
+            id,
+            endpoint,
+            is_ech_retry: true,
+        })
     }
 
     fn endpoints_to_attempt(&self) -> Vec<Endpoint> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -242,6 +242,7 @@ pub fn out_attempt_v6_h1_h2(id: Id) -> Output {
             http_version: ConnectionAttemptHttpVersions::H2OrH1,
             ech_config: None,
         },
+        is_ech_retry: false,
     }
 }
 
@@ -253,6 +254,7 @@ pub fn out_attempt_v6_h2(id: Id) -> Output {
             http_version: ConnectionAttemptHttpVersions::H2,
             ech_config: None,
         },
+        is_ech_retry: false,
     }
 }
 
@@ -264,6 +266,7 @@ pub fn out_attempt_v6_h3(id: Id) -> Output {
             http_version: ConnectionAttemptHttpVersions::H3,
             ech_config: None,
         },
+        is_ech_retry: false,
     }
 }
 
@@ -275,6 +278,7 @@ pub fn out_attempt_v6_h3_custom_port(id: Id) -> Output {
             http_version: ConnectionAttemptHttpVersions::H3,
             ech_config: None,
         },
+        is_ech_retry: false,
     }
 }
 
@@ -286,6 +290,7 @@ pub fn out_attempt_v4_h1_h2(id: Id) -> Output {
             http_version: ConnectionAttemptHttpVersions::H2OrH1,
             ech_config: None,
         },
+        is_ech_retry: false,
     }
 }
 
@@ -297,6 +302,7 @@ pub fn out_attempt_v4_h2(id: Id) -> Output {
             http_version: ConnectionAttemptHttpVersions::H2,
             ech_config: None,
         },
+        is_ech_retry: false,
     }
 }
 
@@ -308,6 +314,7 @@ pub fn out_attempt_v4_h3(id: Id) -> Output {
             http_version: ConnectionAttemptHttpVersions::H3,
             ech_config: None,
         },
+        is_ech_retry: false,
     }
 }
 
@@ -319,6 +326,7 @@ pub fn out_attempt_v4_h3_custom_port(id: Id) -> Output {
             http_version: ConnectionAttemptHttpVersions::H3,
             ech_config: None,
         },
+        is_ech_retry: false,
     }
 }
 
@@ -330,6 +338,7 @@ pub fn out_attempt_v6_h2_custom_port(id: Id) -> Output {
             http_version: ConnectionAttemptHttpVersions::H2,
             ech_config: None,
         },
+        is_ech_retry: false,
     }
 }
 
@@ -341,6 +350,7 @@ pub fn out_attempt_v4_h2_custom_port(id: Id) -> Output {
             http_version: ConnectionAttemptHttpVersions::H2,
             ech_config: None,
         },
+        is_ech_retry: false,
     }
 }
 
@@ -357,6 +367,7 @@ pub fn out_attempt(
             http_version,
             ech_config: None,
         },
+        is_ech_retry: false,
     }
 }
 

--- a/tests/connection_attempts.rs
+++ b/tests/connection_attempts.rs
@@ -146,6 +146,7 @@ fn successful_connection_cancels_others() {
                     http_version: ConnectionAttemptHttpVersions::H2OrH1,
                     ech_config: None,
                 },
+                is_ech_retry: false,
             }),
         )],
         now,

--- a/tests/failure.rs
+++ b/tests/failure.rs
@@ -119,6 +119,7 @@ fn ip_host_connection_failure() {
                         http_version: ConnectionAttemptHttpVersions::H2OrH1,
                         ech_config: None,
                     },
+                    is_ech_retry: false,
                 }),
             ),
             (

--- a/tests/hostname_resolution.rs
+++ b/tests/hostname_resolution.rs
@@ -553,6 +553,7 @@ fn multiple_ips_per_record() {
                     http_version: ConnectionAttemptHttpVersions::H2OrH1,
                     ech_config: None,
                 },
+                is_ech_retry: false,
             }),
         )],
         now,

--- a/tests/https_records.rs
+++ b/tests/https_records.rs
@@ -56,6 +56,7 @@ fn ech_config_propagated_to_endpoint() {
                     http_version: ConnectionAttemptHttpVersions::H3,
                     ech_config: Some(ech_config()),
                 },
+                is_ech_retry: false,
             }),
         )],
         now,
@@ -197,6 +198,7 @@ fn ech_disabled() {
                         http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: None,
                     },
+                    is_ech_retry: false,
                 }),
             ),
         ],
@@ -213,6 +215,7 @@ fn ech_disabled() {
                 http_version: ConnectionAttemptHttpVersions::H2OrH1,
                 ech_config: None,
             },
+            is_ech_retry: false,
         }],
     );
 }
@@ -250,6 +253,7 @@ fn ech_config_from_https_applies_to_aaaa() {
                         http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: Some(ech_config()),
                     },
+                    is_ech_retry: false,
                 }),
             ),
         ],
@@ -282,6 +286,7 @@ fn multiple_target_names() {
                         http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: None,
                     },
+                    is_ech_retry: false,
                 }),
             ),
         ],
@@ -387,6 +392,7 @@ fn partial_ech_two_service_infos() {
                         http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: Some(ech_config()),
                     },
+                    is_ech_retry: false,
                 }),
             ),
         ],
@@ -404,6 +410,7 @@ fn partial_ech_two_service_infos() {
                     http_version: ConnectionAttemptHttpVersions::H2,
                     ech_config: Some(ech_config()),
                 },
+                is_ech_retry: false,
             }),
         )],
         now,
@@ -523,6 +530,7 @@ fn both_service_infos_have_ech_no_origin_fallback() {
                         http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: Some(ech_config()),
                     },
+                    is_ech_retry: false,
                 }),
             ),
             (None, Some(out_connection_attempt_delay())),
@@ -556,6 +564,7 @@ fn both_service_infos_have_ech_no_origin_fallback() {
                     http_version: ConnectionAttemptHttpVersions::H2,
                     ech_config: Some(ech_config()),
                 },
+                is_ech_retry: false,
             },
             // priority=2 (SVC2, port 10443, ech)
             Output::AttemptConnection {
@@ -565,6 +574,7 @@ fn both_service_infos_have_ech_no_origin_fallback() {
                     http_version: ConnectionAttemptHttpVersions::H3,
                     ech_config: Some(ech_config()),
                 },
+                is_ech_retry: false,
             },
             Output::AttemptConnection {
                 id: Id::from(10),
@@ -573,6 +583,7 @@ fn both_service_infos_have_ech_no_origin_fallback() {
                     http_version: ConnectionAttemptHttpVersions::H2,
                     ech_config: Some(ech_config()),
                 },
+                is_ech_retry: false,
             },
         ],
     );
@@ -683,6 +694,7 @@ fn partial_ech_with_alt_svc() {
                         http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: Some(ech_config()),
                     },
+                    is_ech_retry: false,
                 }),
             ),
         ],
@@ -701,6 +713,7 @@ fn partial_ech_with_alt_svc() {
                     http_version: ConnectionAttemptHttpVersions::H2,
                     ech_config: Some(ech_config()),
                 },
+                is_ech_retry: false,
             }),
         )],
         now,
@@ -842,6 +855,7 @@ fn https_port_svcparam_applies_but_fallbacks_follow() {
                         http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: None,
                     },
+                    is_ech_retry: false,
                 }),
             ),
             (
@@ -894,6 +908,7 @@ fn https_two_service_infos_with_different_ports() {
                     http_version,
                     ech_config: None,
                 },
+                is_ech_retry: false,
             }
         };
 
@@ -1108,6 +1123,7 @@ fn https_svc1_addresses_trigger_additional_attempts() {
                 http_version,
                 ech_config: None,
             },
+            is_ech_retry: false,
         }
     };
 
@@ -1314,6 +1330,7 @@ fn target_name_redirect_addresses_used_in_connection_attempts() {
                         http_version: ConnectionAttemptHttpVersions::H3,
                         ech_config: None,
                     },
+                    is_ech_retry: false,
                 }),
             ),
             (None, Some(out_connection_attempt_delay())),
@@ -1350,6 +1367,7 @@ fn target_name_redirect_addresses_used_in_connection_attempts() {
                     http_version: ConnectionAttemptHttpVersions::H3,
                     ech_config: None,
                 },
+                is_ech_retry: false,
             },
             // fallback bucket (origin)
             out_attempt_v6_h1_h2(Id::from(7)),
@@ -1458,6 +1476,7 @@ fn ech_retry_same_endpoint() {
                         http_version: ConnectionAttemptHttpVersions::H2,
                         ech_config: Some(ech_config()),
                     },
+                    is_ech_retry: false,
                 }),
             ),
             (None, Some(out_connection_attempt_delay())),
@@ -1477,6 +1496,70 @@ fn ech_retry_same_endpoint() {
                         http_version: ConnectionAttemptHttpVersions::H2,
                         ech_config: Some(new_ech_config.clone()),
                     },
+                    is_ech_retry: true,
+                }),
+            ),
+        ],
+        now,
+    );
+}
+
+/// `EchRetry` with an empty `EchConfig` models the SSL_ERROR_ECH_RETRY_WITHOUT_ECH
+/// path on the consumer side (server told us to retry *without* ECH). The state
+/// machine forwards the bytes verbatim, but the retry attempt must still be
+/// flagged `is_ech_retry: true` so consumers can label it.
+#[test]
+fn ech_retry_without_ech_sets_flag() {
+    let (now, mut he) = setup();
+
+    let empty_ech_config = EchConfig::new(vec![]);
+
+    he.expect(
+        vec![
+            (None, Some(out_send_dns_https(Id::from(0)))),
+            (None, Some(out_send_dns_aaaa(Id::from(1)))),
+            (None, Some(out_send_dns_a(Id::from(2)))),
+            (
+                Some(Input::DnsResult {
+                    id: Id::from(0),
+                    result: DnsResult::Https(Ok(vec![ServiceInfo {
+                        priority: 1,
+                        target_name: HOSTNAME.into(),
+                        alpn_http_versions: HashSet::from([HttpVersion::H2]),
+                        ipv6_hints: vec![],
+                        ipv4_hints: vec![],
+                        ech_config: Some(ech_config()),
+                        port: None,
+                    }])),
+                }),
+                Some(out_resolution_delay()),
+            ),
+            (
+                Some(in_dns_aaaa_positive(Id::from(1))),
+                Some(Output::AttemptConnection {
+                    id: Id::from(3),
+                    endpoint: Endpoint {
+                        address: SocketAddr::new(V6_ADDR.into(), PORT),
+                        http_version: ConnectionAttemptHttpVersions::H2,
+                        ech_config: Some(ech_config()),
+                    },
+                    is_ech_retry: false,
+                }),
+            ),
+            (None, Some(out_connection_attempt_delay())),
+            (
+                Some(Input::ConnectionResult {
+                    id: Id::from(3),
+                    result: ConnectionResult::EchRetry(empty_ech_config.clone()),
+                }),
+                Some(Output::AttemptConnection {
+                    id: Id::from(4),
+                    endpoint: Endpoint {
+                        address: SocketAddr::new(V6_ADDR.into(), PORT),
+                        http_version: ConnectionAttemptHttpVersions::H2,
+                        ech_config: Some(empty_ech_config.clone()),
+                    },
+                    is_ech_retry: true,
                 }),
             ),
         ],
@@ -1527,6 +1610,7 @@ fn ech_retry_no_infinite_loop() {
                         http_version: ConnectionAttemptHttpVersions::H2,
                         ech_config: Some(ech_config()),
                     },
+                    is_ech_retry: false,
                 }),
             ),
             (None, Some(out_connection_attempt_delay())),
@@ -1543,6 +1627,7 @@ fn ech_retry_no_infinite_loop() {
                         http_version: ConnectionAttemptHttpVersions::H2,
                         ech_config: Some(retry_ech_config.clone()),
                     },
+                    is_ech_retry: true,
                 }),
             ),
             (None, Some(out_connection_attempt_delay())),
@@ -1566,6 +1651,7 @@ fn ech_retry_no_infinite_loop() {
                         http_version: ConnectionAttemptHttpVersions::H2,
                         ech_config: Some(ech_config()),
                     },
+                    is_ech_retry: false,
                 }),
             ),
         ],


### PR DESCRIPTION
The state machine already tracks whether a connection attempt was scheduled in response to an EchRetry input (ConnectionAttempt.is_ech_retry, set inside ech_retry_attempt). Consumers, however, currently have no way to read that bit and must infer it from event ordering — typically by assuming the next AttemptConnection after process_input(EchRetry) is the retry. That assumption holds today only because ech_retry_attempt() runs first inside connection_attempt(); any future reordering or interleaving breaks it silently.

Expose the bit on Output::AttemptConnection so the answer travels with the event it describes. Both emission sites already know the value.

Adds two retry-flag tests: ech_retry_same_endpoint covers the config-updated path, ech_retry_without_ech_sets_flag covers the SSL_ERROR_ECH_RETRY_WITHOUT_ECH (empty EchConfig) path.