### PR TITLE
Add HTTPS-RR / CNAME consistency check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "happy-eyeballs"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "happy-eyeballs"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! // Later pass results as input back to the state machine, e.g. a DNS
 //! // response arrives:
-//! # let dns_result = DnsResult::Aaaa(Ok(vec![Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)]));
+//! # let dns_result = DnsResult::Aaaa(Ok(vec![Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)]), None);
 //! he.process_input(Input::DnsResult { id: dns_id.unwrap(), result: dns_result }, Instant::now());
 //! ```
 //!
@@ -128,8 +128,14 @@ pub enum ConnectionResult {
 #[derive(Debug, Clone, PartialEq)]
 pub enum DnsResult {
     Https(Result<Vec<ServiceInfo>, ()>),
-    Aaaa(Result<Vec<Ipv6Addr>, ()>),
-    A(Result<Vec<Ipv4Addr>, ()>),
+    /// AAAA answer plus the canonical name (final target of the CNAME chain)
+    /// reported by the resolver for this query, if any. The canonical name is
+    /// only consulted for the origin query, where it is used to drop HTTPS
+    /// records whose `TargetName` is inconsistent with it.
+    Aaaa(Result<Vec<Ipv6Addr>, ()>, Option<TargetName>),
+    /// A answer plus the canonical name reported by the resolver, if any. See
+    /// [`DnsResult::Aaaa`].
+    A(Result<Vec<Ipv4Addr>, ()>, Option<TargetName>),
 }
 
 impl DnsResult {
@@ -137,8 +143,8 @@ impl DnsResult {
     /// non-empty AAAA/A records or HTTPS records with IP hints.
     fn has_addrs(&self) -> bool {
         match self {
-            DnsResult::Aaaa(Ok(v)) => !v.is_empty(),
-            DnsResult::A(Ok(v)) => !v.is_empty(),
+            DnsResult::Aaaa(Ok(v), _) => !v.is_empty(),
+            DnsResult::A(Ok(v), _) => !v.is_empty(),
             DnsResult::Https(Ok(infos)) => infos
                 .iter()
                 .any(|i| !i.ipv4_hints.is_empty() || !i.ipv6_hints.is_empty()),
@@ -146,13 +152,21 @@ impl DnsResult {
         }
     }
 
+    /// The canonical name reported by an A/AAAA answer, if any.
+    fn canonical_name(&self) -> Option<&TargetName> {
+        match self {
+            DnsResult::Aaaa(_, cname) | DnsResult::A(_, cname) => cname.as_ref(),
+            DnsResult::Https(_) => None,
+        }
+    }
+
     fn ip_addrs(&self) -> impl Iterator<Item = IpAddr> + '_ {
         let v6 = match self {
-            DnsResult::Aaaa(Ok(addrs)) => addrs.as_slice(),
+            DnsResult::Aaaa(Ok(addrs), _) => addrs.as_slice(),
             _ => &[],
         };
         let v4 = match self {
-            DnsResult::A(Ok(addrs)) => addrs.as_slice(),
+            DnsResult::A(Ok(addrs), _) => addrs.as_slice(),
             _ => &[],
         };
         v6.iter()
@@ -203,6 +217,19 @@ impl Debug for TargetName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
+}
+
+/// Compares two DNS names for the HTTPS-RR / CNAME consistency check.
+///
+/// DNS names are case-insensitive (RFC 4343) and the representation may or may
+/// not carry a trailing dot depending on the source (an HTTPS record's
+/// `TargetName` versus a resolver-reported canonical name). Both are normalised
+/// before comparison so e.g. `Svc.Example.Com.` matches `svc.example.com`.
+fn target_names_match(a: &str, b: &str) -> bool {
+    fn normalize(s: &str) -> &str {
+        s.strip_suffix('.').unwrap_or(s)
+    }
+    normalize(a).eq_ignore_ascii_case(normalize(b))
 }
 
 /// Output events from the Happy Eyeballs state machine
@@ -670,6 +697,16 @@ enum Host {
     Domain(String),
 }
 
+impl Host {
+    /// The domain, or `None` when connecting to an IP literal.
+    fn domain(&self) -> Option<&str> {
+        match self {
+            Host::Domain(d) => Some(d.as_str()),
+            Host::Ip(_) => None,
+        }
+    }
+}
+
 impl From<UrlHost> for Host {
     fn from(host: UrlHost) -> Self {
         match host {
@@ -940,23 +977,18 @@ impl HappyEyeballs {
     fn send_dns_request_for_target_name(&mut self) -> Option<Output> {
         let any_ech = self.any_ech();
 
-        let target_names = self
-            .dns_queries
-            .iter()
-            .filter_map(|q| match &q.state {
-                DnsQueryState::Completed {
-                    response: DnsResult::Https(Ok(service_infos)),
-                    ..
-                } => Some(service_infos.iter()),
-                _ => None,
-            })
-            .flatten()
+        let target_names: Vec<TargetName> = self
+            .usable_service_infos()
+            .into_iter()
+            // CNAME-inconsistent ServiceInfos are already excluded by usable_service_infos.
             // When any ServiceInfo has ECH, skip resolving targets without ECH.
-            .filter(move |i| !any_ech || i.ech_config.is_some())
-            .map(|i| &i.target_name);
+            .filter(|i| !any_ech || i.ech_config.is_some())
+            .map(|i| i.target_name.clone())
+            .collect();
 
         // Next AAAA or A query, respecting single-stack preferences.
         let (target_name, record_type) = target_names
+            .iter()
             .flat_map(|tn| {
                 self.network_config
                     .ip
@@ -1197,18 +1229,11 @@ impl HappyEyeballs {
     fn endpoints_to_attempt_domain(&self, origin_domain: &str) -> Vec<Endpoint> {
         let any_ech = self.any_ech();
 
-        // Collect all ServiceInfos sorted by priority.
+        // Collect usable ServiceInfos (CNAME-consistent, per config) sorted by
+        // priority.
         let mut service_infos: Vec<&ServiceInfo> = self
-            .dns_queries
-            .iter()
-            .filter_map(|q| match &q.state {
-                DnsQueryState::Completed {
-                    response: DnsResult::Https(Ok(infos)),
-                    ..
-                } => Some(infos.as_slice()),
-                _ => None,
-            })
-            .flatten()
+            .usable_service_infos()
+            .into_iter()
             // When at least one ServiceInfo has ECH config, skip those without it
             // and skip the origin fallback.
             .filter(|i| !any_ech || i.ech_config.is_some())
@@ -1222,7 +1247,7 @@ impl HappyEyeballs {
             let ipv4_addrs: Option<&[Ipv4Addr]> =
                 self.dns_queries.iter().find_map(|q| match &q.state {
                     DnsQueryState::Completed {
-                        response: DnsResult::A(result),
+                        response: DnsResult::A(result, _),
                         ..
                     } if q.target_name == info.target_name => {
                         Some(result.as_deref().unwrap_or_default())
@@ -1232,7 +1257,7 @@ impl HappyEyeballs {
             let ipv6_addrs: Option<&[Ipv6Addr]> =
                 self.dns_queries.iter().find_map(|q| match &q.state {
                     DnsQueryState::Completed {
-                        response: DnsResult::Aaaa(result),
+                        response: DnsResult::Aaaa(result, _),
                         ..
                     } if q.target_name == info.target_name => {
                         Some(result.as_deref().unwrap_or_default())
@@ -1260,7 +1285,7 @@ impl HappyEyeballs {
                     .iter()
                     .filter_map(|q| match &q.state {
                         DnsQueryState::Completed {
-                            response: r @ (DnsResult::Aaaa(_) | DnsResult::A(_)),
+                            response: r @ (DnsResult::Aaaa(..) | DnsResult::A(..)),
                             ..
                         } if q.target_name.as_str() == origin_domain => Some(r),
                         _ => None,
@@ -1309,13 +1334,68 @@ impl HappyEyeballs {
         if !self.network_config.ech {
             return false;
         }
-        self.dns_queries.iter().any(|q| match &q.state {
-            DnsQueryState::Completed {
-                response: DnsResult::Https(Ok(infos)),
-                ..
-            } => infos.iter().any(|i| i.ech_config.is_some()),
-            _ => false,
+        self.usable_service_infos()
+            .iter()
+            .any(|i| i.ech_config.is_some())
+    }
+
+    /// Canonical names reported by the origin's completed A/AAAA resolutions.
+    ///
+    /// These drive the HTTPS-RR / CNAME consistency check. There may be more
+    /// than one (e.g. A and AAAA steering to different CDNs).
+    fn origin_canonical_names(&self, origin_domain: &str) -> Vec<&TargetName> {
+        self.dns_queries
+            .iter()
+            .filter(|q| q.target_name.as_str() == origin_domain)
+            .filter_map(|q| match &q.state {
+                DnsQueryState::Completed { response, .. } => response.canonical_name(),
+                DnsQueryState::InProgress => None,
+            })
+            .collect()
+    }
+
+    /// ServiceInfos from completed HTTPS responses that are usable for this
+    /// connection.
+    ///
+    /// When the origin's A/AAAA resolution reported a canonical name,
+    /// ServiceInfos whose `TargetName` is inconsistent with every reported
+    /// canonical name are dropped. A ServiceInfo is kept if its `TargetName`
+    /// matches the canonical name of either address family. When no canonical
+    /// name was reported, all ServiceInfos are returned unchanged.
+    ///
+    /// This runs before the ECH-based filtering so that dropping an
+    /// inconsistent ECH record lets the origin fallback re-engage, i.e. the
+    /// connection prefers the CNAME over a broken ECH target.
+    fn usable_service_infos(&self) -> Vec<&ServiceInfo> {
+        let all = self
+            .dns_queries
+            .iter()
+            .filter_map(|q| match &q.state {
+                DnsQueryState::Completed {
+                    response: DnsResult::Https(Ok(infos)),
+                    ..
+                } => Some(infos.iter()),
+                _ => None,
+            })
+            .flatten();
+
+        let Some(origin) = self.host.domain() else {
+            return all.collect();
+        };
+
+        let cnames = self.origin_canonical_names(origin);
+        if cnames.is_empty() {
+            // No canonical name reported: do not filter.
+            return all.collect();
+        }
+
+        // TODO: ideally we wouldn't allocate (i.e. not call collect) here.
+        all.filter(|i| {
+            cnames
+                .iter()
+                .any(|c| target_names_match(i.target_name.as_str(), c.as_str()))
         })
+        .collect()
     }
 
     /// HTTP versions when the host is an IP address (no DNS involved).
@@ -1335,20 +1415,9 @@ impl HappyEyeballs {
         let mut http_versions = HashSet::new();
 
         http_versions.extend(
-            self.dns_queries
+            self.usable_service_infos()
                 .iter()
-                .filter_map(|q| match &q.state {
-                    DnsQueryState::Completed {
-                        response: DnsResult::Https(Ok(infos)),
-                        ..
-                    } => Some(
-                        infos
-                            .iter()
-                            .flat_map(|i| i.alpn_http_versions.iter().cloned()),
-                    ),
-                    _ => None,
-                })
-                .flatten(),
+                .flat_map(|i| i.alpn_http_versions.iter().cloned()),
         );
 
         if http_versions.is_empty() {
@@ -1496,17 +1565,17 @@ mod tests {
     #[test]
     fn dns_result_has_addrs() {
         for result in [
-            DnsResult::Aaaa(Ok(vec![])),
-            DnsResult::Aaaa(Err(())),
-            DnsResult::A(Ok(vec![])),
-            DnsResult::A(Err(())),
+            DnsResult::Aaaa(Ok(vec![]), None),
+            DnsResult::Aaaa(Err(()), None),
+            DnsResult::A(Ok(vec![]), None),
+            DnsResult::A(Err(()), None),
             DnsResult::Https(Err(())),
             DnsResult::Https(Ok(vec![])),
         ] {
             assert!(!result.has_addrs());
         }
-        assert!(DnsResult::Aaaa(Ok(vec![Ipv6Addr::LOCALHOST])).has_addrs());
-        assert!(DnsResult::A(Ok(vec![Ipv4Addr::LOCALHOST])).has_addrs());
+        assert!(DnsResult::Aaaa(Ok(vec![Ipv6Addr::LOCALHOST]), None).has_addrs());
+        assert!(DnsResult::A(Ok(vec![Ipv4Addr::LOCALHOST]), None).has_addrs());
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -156,28 +156,28 @@ pub fn in_dns_https_negative(id: Id) -> Input {
 pub fn in_dns_aaaa_positive(id: Id) -> Input {
     Input::DnsResult {
         id,
-        result: DnsResult::Aaaa(Ok(vec![V6_ADDR])),
+        result: DnsResult::Aaaa(Ok(vec![V6_ADDR]), None),
     }
 }
 
 pub fn in_dns_a_positive(id: Id) -> Input {
     Input::DnsResult {
         id,
-        result: DnsResult::A(Ok(vec![V4_ADDR])),
+        result: DnsResult::A(Ok(vec![V4_ADDR]), None),
     }
 }
 
 pub fn in_dns_aaaa_negative(id: Id) -> Input {
     Input::DnsResult {
         id,
-        result: DnsResult::Aaaa(Err(())),
+        result: DnsResult::Aaaa(Err(()), None),
     }
 }
 
 pub fn in_dns_a_negative(id: Id) -> Input {
     Input::DnsResult {
         id,
-        result: DnsResult::A(Err(())),
+        result: DnsResult::A(Err(()), None),
     }
 }
 

--- a/tests/connection_attempts.rs
+++ b/tests/connection_attempts.rs
@@ -115,7 +115,7 @@ fn successful_connection_cancels_others() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(1),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR, V6_ADDR_2])),
+                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR, V6_ADDR_2]), None),
                 }),
                 Some(out_attempt_v6_h1_h2(Id::from(3))),
             ),

--- a/tests/hostname_resolution.rs
+++ b/tests/hostname_resolution.rs
@@ -494,7 +494,7 @@ fn multiple_ips_per_record() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(1),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR, V6_ADDR_2, V6_ADDR_3])),
+                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR, V6_ADDR_2, V6_ADDR_3]), None),
                 }),
                 Some(out_attempt_v6_h1_h2(Id::from(3))),
             ),

--- a/tests/https_records.rs
+++ b/tests/https_records.rs
@@ -361,7 +361,7 @@ fn partial_ech_two_service_infos() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(4),
-                    result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+                    result: DnsResult::A(Ok(vec![V4_ADDR_2]), None),
                 }),
                 Some(Output::AttemptConnection {
                     id: Id::from(5),
@@ -481,7 +481,7 @@ fn both_service_infos_have_ech_no_origin_fallback() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(4),
-                    result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+                    result: DnsResult::A(Ok(vec![V4_ADDR_2]), None),
                 }),
                 Some(Output::AttemptConnection {
                     id: Id::from(7),
@@ -503,7 +503,7 @@ fn both_service_infos_have_ech_no_origin_fallback() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(6),
-                    result: DnsResult::A(Ok(vec![V4_ADDR])),
+                    result: DnsResult::A(Ok(vec![V4_ADDR]), None),
                 }),
                 Some(out_connection_attempt_delay()),
             ),
@@ -635,7 +635,7 @@ fn partial_ech_with_alt_svc() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(4),
-                    result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+                    result: DnsResult::A(Ok(vec![V4_ADDR_2]), None),
                 }),
                 Some(Output::AttemptConnection {
                     id: Id::from(5),
@@ -1028,14 +1028,14 @@ fn https_svc1_addresses_trigger_additional_attempts() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(3),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
+                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2]), None),
                 }),
                 Some(out_connection_attempt_delay()),
             ),
             (
                 Some(Input::DnsResult {
                     id: Id::from(4),
-                    result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+                    result: DnsResult::A(Ok(vec![V4_ADDR_2]), None),
                 }),
                 Some(out_connection_attempt_delay()),
             ),
@@ -1237,7 +1237,7 @@ fn target_name_redirect_addresses_used_in_connection_attempts() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(3),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
+                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2]), None),
                 }),
                 Some(Output::AttemptConnection {
                     id: Id::from(5),
@@ -1254,7 +1254,7 @@ fn target_name_redirect_addresses_used_in_connection_attempts() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(4),
-                    result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+                    result: DnsResult::A(Ok(vec![V4_ADDR_2]), None),
                 }),
                 Some(out_connection_attempt_delay()),
             ),

--- a/tests/https_rr_cname.rs
+++ b/tests/https_rr_cname.rs
@@ -1,0 +1,493 @@
+//! Tests for the HTTPS-RR / CNAME consistency check.
+//!
+//! When the origin's A/AAAA resolution reports a canonical name, an HTTPS
+//! record whose `TargetName` is inconsistent with that canonical name is
+//! dropped, and the connection prefers the origin's plain A/AAAA addresses.
+//! This behaviour was originally introduced in Firefox to prevent broken ECH
+//! handshakes when dual-CDN steering points the HTTPS record at one CDN while
+//! the A/AAAA CNAME chain steers to another.
+
+mod common;
+use common::*;
+
+use std::{
+    collections::HashSet,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    time::Instant,
+};
+
+use happy_eyeballs::{
+    ConnectionResult, DnsRecordType, DnsResult, Endpoint, HappyEyeballs, HttpVersion, Id, Input,
+    NetworkConfig, Output, ServiceInfo,
+};
+
+/// HTTPS record `TargetName`: a CDN distinct from the origin, carrying ECH.
+const CDN_A: &str = "cdn-a.example.net.";
+/// A different CDN the origin's CNAME chain might steer to.
+const CDN_B: &str = "cdn-b.example.net.";
+
+/// Origin (example.com) addresses, reached via the plain A/AAAA / CNAME path.
+const ORIGIN_V6: Ipv6Addr = V6_ADDR;
+const ORIGIN_V4: Ipv4Addr = V4_ADDR;
+/// Addresses the HTTPS record's TargetName (CDN_A) resolves to.
+const CDN_A_V6: Ipv6Addr = V6_ADDR_2;
+const CDN_A_V4: Ipv4Addr = V4_ADDR_2;
+
+/// A single ECH-bearing HTTPS record pointing at `target`.
+fn https_ech_record(target: &str) -> DnsResult {
+    DnsResult::Https(Ok(vec![ServiceInfo {
+        priority: 1,
+        target_name: target.into(),
+        alpn_http_versions: HashSet::from([HttpVersion::H2, HttpVersion::H3]),
+        ipv6_hints: vec![],
+        ipv4_hints: vec![],
+        ech_config: Some(ech_config()),
+        port: None,
+    }]))
+}
+
+/// Case- and trailing-dot-insensitive name comparison, matching the crate's
+/// own normalization, used by the test answer functions.
+fn same_name(a: &str, b: &str) -> bool {
+    a.trim_end_matches('.')
+        .eq_ignore_ascii_case(b.trim_end_matches('.'))
+}
+
+/// Drive the state machine to completion, answering each DNS query via
+/// `answer` (in the order the machine emits them) and failing every connection
+/// attempt so the next is produced. Returns the endpoints that were attempted.
+fn run(config: NetworkConfig, answer: impl Fn(&str, DnsRecordType) -> DnsResult) -> Vec<Endpoint> {
+    let mut now = Instant::now();
+    let mut he = HappyEyeballs::new_with_network_config(HOSTNAME, PORT, config).unwrap();
+    collect_attempts(&mut he, &mut now, Some(&answer))
+}
+
+/// Answers a DNS query for `(hostname, record_type)` with a [`DnsResult`].
+type AnswerFn<'a> = &'a dyn Fn(&str, DnsRecordType) -> DnsResult;
+
+/// Drive the machine, advancing timers, collecting connection attempts (failing
+/// each), and optionally answering DNS queries via `answer`. Stops when the
+/// machine stalls, succeeds, fails, or (when `answer` is `None`) emits an
+/// unanswered DNS query.
+fn collect_attempts(
+    he: &mut HappyEyeballs,
+    now: &mut Instant,
+    answer: Option<AnswerFn>,
+) -> Vec<Endpoint> {
+    let mut attempts = Vec::new();
+    for _ in 0..10_000 {
+        match he.process_output(*now) {
+            Some(Output::AttemptConnection { id, endpoint, .. }) => {
+                attempts.push(endpoint);
+                he.process_input(
+                    Input::ConnectionResult {
+                        id,
+                        result: ConnectionResult::Failure("fail".to_string()),
+                    },
+                    *now,
+                );
+            }
+            Some(Output::Timer { duration }) => *now += duration,
+            Some(Output::CancelConnection { .. }) => {}
+            Some(Output::SendDnsQuery {
+                id,
+                hostname,
+                record_type,
+            }) => {
+                let Some(answer) = answer else {
+                    break;
+                };
+                let hostname: String = hostname.into();
+                let result = answer(&hostname, record_type);
+                he.process_input(Input::DnsResult { id, result }, *now);
+            }
+            Some(Output::Succeeded) | Some(Output::Failed(_)) | None => break,
+        }
+    }
+    attempts
+}
+
+fn attempted_addrs(endpoints: &[Endpoint]) -> HashSet<IpAddr> {
+    endpoints.iter().map(|e| e.address.ip()).collect()
+}
+
+fn any_ech(endpoints: &[Endpoint]) -> bool {
+    endpoints.iter().any(|e| e.ech_config.is_some())
+}
+
+fn all_ech(endpoints: &[Endpoint]) -> bool {
+    !endpoints.is_empty() && endpoints.iter().all(|e| e.ech_config.is_some())
+}
+
+/// Answer function: origin resolves with canonical name `origin_cname`; the
+/// HTTPS TargetName CDN_A resolves to its own addresses.
+fn answer_with_origin_cname(
+    origin_cname: Option<&'static str>,
+) -> impl Fn(&str, DnsRecordType) -> DnsResult {
+    move |hostname: &str, record_type: DnsRecordType| {
+        let cname = origin_cname.map(|c| c.into());
+        match record_type {
+            DnsRecordType::Https => https_ech_record(CDN_A),
+            DnsRecordType::Aaaa if same_name(hostname, HOSTNAME) => {
+                DnsResult::Aaaa(Ok(vec![ORIGIN_V6]), cname)
+            }
+            DnsRecordType::A if same_name(hostname, HOSTNAME) => {
+                DnsResult::A(Ok(vec![ORIGIN_V4]), cname)
+            }
+            DnsRecordType::Aaaa if same_name(hostname, CDN_A) => {
+                DnsResult::Aaaa(Ok(vec![CDN_A_V6]), None)
+            }
+            DnsRecordType::A if same_name(hostname, CDN_A) => {
+                DnsResult::A(Ok(vec![CDN_A_V4]), None)
+            }
+            DnsRecordType::Aaaa => DnsResult::Aaaa(Err(()), None),
+            DnsRecordType::A => DnsResult::A(Err(()), None),
+        }
+    }
+}
+
+/// Matching CNAME: the origin steers to the same CDN the HTTPS record points
+/// at, so the record is used (ECH endpoints at the CDN's addresses).
+#[test]
+fn matching_cname_record_used() {
+    let attempts = run(
+        NetworkConfig::default(),
+        answer_with_origin_cname(Some(CDN_A)),
+    );
+
+    assert_eq!(
+        attempted_addrs(&attempts),
+        HashSet::from([CDN_A_V6.into(), CDN_A_V4.into()]),
+    );
+    assert!(
+        all_ech(&attempts),
+        "ECH must be carried to the CDN endpoints"
+    );
+}
+
+/// Mismatching CNAME: the origin steers (via CNAME) to a different CDN than the
+/// HTTPS record's TargetName. The record is dropped and we connect to the
+/// origin's plain A/AAAA addresses without ECH ("prefer the CNAME").
+#[test]
+fn mismatching_cname_record_dropped() {
+    let attempts = run(
+        NetworkConfig::default(),
+        answer_with_origin_cname(Some(CDN_B)),
+    );
+
+    assert_eq!(
+        attempted_addrs(&attempts),
+        HashSet::from([ORIGIN_V6.into(), ORIGIN_V4.into()]),
+    );
+    assert!(
+        !any_ech(&attempts),
+        "the broken ECH target must not be attempted"
+    );
+    let cdn: HashSet<IpAddr> = HashSet::from([CDN_A_V6.into(), CDN_A_V4.into()]);
+    assert!(
+        attempted_addrs(&attempts).is_disjoint(&cdn),
+        "the CDN behind the dropped record must never be attempted"
+    );
+}
+
+/// No canonical name reported by the origin resolution: no filtering, the
+/// record is used (mirrors legacy "empty cname => record stays usable").
+#[test]
+fn empty_cname_no_filtering() {
+    let attempts = run(NetworkConfig::default(), answer_with_origin_cname(None));
+
+    assert_eq!(
+        attempted_addrs(&attempts),
+        HashSet::from([CDN_A_V6.into(), CDN_A_V4.into()]),
+    );
+    assert!(all_ech(&attempts));
+}
+
+/// Case- and trailing-dot-insensitive matching: the HTTPS TargetName and the
+/// reported canonical name differ only in case and trailing dot, yet match.
+#[test]
+fn cname_match_is_case_and_trailing_dot_insensitive() {
+    let target = "CDN-A.Example.NET"; // mixed case, no trailing dot
+    let origin_cname = "cdn-a.example.net."; // lower case, trailing dot
+
+    let attempts = run(
+        NetworkConfig::default(),
+        move |hostname: &str, record_type| match record_type {
+            DnsRecordType::Https => https_ech_record(target),
+            DnsRecordType::Aaaa if same_name(hostname, HOSTNAME) => {
+                DnsResult::Aaaa(Ok(vec![ORIGIN_V6]), Some(origin_cname.into()))
+            }
+            DnsRecordType::A if same_name(hostname, HOSTNAME) => {
+                DnsResult::A(Ok(vec![ORIGIN_V4]), Some(origin_cname.into()))
+            }
+            DnsRecordType::Aaaa if same_name(hostname, target) => {
+                DnsResult::Aaaa(Ok(vec![CDN_A_V6]), None)
+            }
+            DnsRecordType::A if same_name(hostname, target) => {
+                DnsResult::A(Ok(vec![CDN_A_V4]), None)
+            }
+            DnsRecordType::Aaaa => DnsResult::Aaaa(Err(()), None),
+            DnsRecordType::A => DnsResult::A(Err(()), None),
+        },
+    );
+
+    assert_eq!(
+        attempted_addrs(&attempts),
+        HashSet::from([CDN_A_V6.into(), CDN_A_V4.into()]),
+        "names matching modulo case/trailing-dot must be treated as consistent"
+    );
+    assert!(all_ech(&attempts));
+}
+
+/// A and AAAA report different canonical names. A ServiceInfo passes if its
+/// TargetName matches EITHER family's canonical name. Here AAAA steers to
+/// CDN_A (the record's target) while A steers to CDN_B, so the record is kept.
+#[test]
+fn passes_when_matching_either_address_family() {
+    let attempts = run(NetworkConfig::default(), |hostname: &str, record_type| {
+        match record_type {
+            DnsRecordType::Https => https_ech_record(CDN_A),
+            // AAAA canonical name matches the record's target.
+            DnsRecordType::Aaaa if same_name(hostname, HOSTNAME) => {
+                DnsResult::Aaaa(Ok(vec![ORIGIN_V6]), Some(CDN_A.into()))
+            }
+            // A canonical name does not.
+            DnsRecordType::A if same_name(hostname, HOSTNAME) => {
+                DnsResult::A(Ok(vec![ORIGIN_V4]), Some(CDN_B.into()))
+            }
+            DnsRecordType::Aaaa if same_name(hostname, CDN_A) => {
+                DnsResult::Aaaa(Ok(vec![CDN_A_V6]), None)
+            }
+            DnsRecordType::A if same_name(hostname, CDN_A) => {
+                DnsResult::A(Ok(vec![CDN_A_V4]), None)
+            }
+            DnsRecordType::Aaaa => DnsResult::Aaaa(Err(()), None),
+            DnsRecordType::A => DnsResult::A(Err(()), None),
+        }
+    });
+
+    assert_eq!(
+        attempted_addrs(&attempts),
+        HashSet::from([CDN_A_V6.into(), CDN_A_V4.into()]),
+        "matching either family's canonical name keeps the record"
+    );
+    assert!(all_ech(&attempts));
+}
+
+/// Arrival order: origin A/AAAA (with the mismatching canonical name) arrive
+/// BEFORE the HTTPS record. The record is filtered as soon as it arrives.
+#[test]
+fn order_origin_before_https_filters_record() {
+    let mut now = Instant::now();
+    let mut he =
+        HappyEyeballs::new_with_network_config(HOSTNAME, PORT, NetworkConfig::default()).unwrap();
+
+    expect_query(&mut he, now, 0, HOSTNAME, DnsRecordType::Https);
+    expect_query(&mut he, now, 1, HOSTNAME, DnsRecordType::Aaaa);
+    expect_query(&mut he, now, 2, HOSTNAME, DnsRecordType::A);
+
+    // Origin A/AAAA first, reporting the mismatching canonical name.
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(1),
+            result: DnsResult::Aaaa(Ok(vec![ORIGIN_V6]), Some(CDN_B.into())),
+        },
+        now,
+    );
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(2),
+            result: DnsResult::A(Ok(vec![ORIGIN_V4]), Some(CDN_B.into())),
+        },
+        now,
+    );
+    // HTTPS record arrives last; it is inconsistent with the known CNAME.
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: https_ech_record(CDN_A),
+        },
+        now,
+    );
+
+    let attempts = collect_attempts(&mut he, &mut now, None);
+    assert_eq!(
+        attempted_addrs(&attempts),
+        HashSet::from([ORIGIN_V6.into(), ORIGIN_V4.into()]),
+    );
+    assert!(!any_ech(&attempts));
+}
+
+/// Arrival order: the HTTPS record arrives BEFORE the origin A/AAAA, so the
+/// canonical name is not yet known and the target is fanned out. Once the
+/// origin A/AAAA arrive with the mismatching canonical name, the record is
+/// filtered retroactively and we prefer the origin addresses.
+#[test]
+fn order_https_before_origin_filters_record_retroactively() {
+    let mut now = Instant::now();
+    let mut he =
+        HappyEyeballs::new_with_network_config(HOSTNAME, PORT, NetworkConfig::default()).unwrap();
+
+    expect_query(&mut he, now, 0, HOSTNAME, DnsRecordType::Https);
+    expect_query(&mut he, now, 1, HOSTNAME, DnsRecordType::Aaaa);
+    expect_query(&mut he, now, 2, HOSTNAME, DnsRecordType::A);
+
+    // HTTPS first: with no canonical name yet, the target is treated as usable
+    // and gets fanned out (ids 3, 4).
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: https_ech_record(CDN_A),
+        },
+        now,
+    );
+    expect_query(&mut he, now, 3, CDN_A, DnsRecordType::Aaaa);
+    expect_query(&mut he, now, 4, CDN_A, DnsRecordType::A);
+
+    // Origin A/AAAA arrive with the mismatching canonical name.
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(1),
+            result: DnsResult::Aaaa(Ok(vec![ORIGIN_V6]), Some(CDN_B.into())),
+        },
+        now,
+    );
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(2),
+            result: DnsResult::A(Ok(vec![ORIGIN_V4]), Some(CDN_B.into())),
+        },
+        now,
+    );
+    // The (now irrelevant) target answers complete too.
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(3),
+            result: DnsResult::Aaaa(Err(()), None),
+        },
+        now,
+    );
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(4),
+            result: DnsResult::A(Err(()), None),
+        },
+        now,
+    );
+
+    let attempts = collect_attempts(&mut he, &mut now, None);
+    assert_eq!(
+        attempted_addrs(&attempts),
+        HashSet::from([ORIGIN_V6.into(), ORIGIN_V4.into()]),
+        "the record is filtered retroactively once the CNAME is known"
+    );
+    assert!(!any_ech(&attempts));
+    let cdn: HashSet<IpAddr> = HashSet::from([CDN_A_V6.into(), CDN_A_V4.into()]);
+    assert!(attempted_addrs(&attempts).is_disjoint(&cdn));
+}
+
+/// HTTPS arrives first, an in-progress connection attempt to the CDN target is
+/// started, then the origin AAAA arrives with a mismatching canonical name.
+/// The in-progress attempt is NOT cancelled; the HTTPS record is ignored for
+/// any subsequent attempts.
+#[test]
+fn in_progress_attempt_continues_after_retroactive_cname_filter() {
+    let mut now = Instant::now();
+    let mut he =
+        HappyEyeballs::new_with_network_config(HOSTNAME, PORT, NetworkConfig::default()).unwrap();
+
+    expect_query(&mut he, now, 0, HOSTNAME, DnsRecordType::Https);
+    expect_query(&mut he, now, 1, HOSTNAME, DnsRecordType::Aaaa);
+    expect_query(&mut he, now, 2, HOSTNAME, DnsRecordType::A);
+
+    // HTTPS arrives first; fan out A/AAAA for CDN_A.
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: https_ech_record(CDN_A),
+        },
+        now,
+    );
+    expect_query(&mut he, now, 3, CDN_A, DnsRecordType::Aaaa);
+    expect_query(&mut he, now, 4, CDN_A, DnsRecordType::A);
+
+    // CDN_A target resolves; once both addresses are available the machine
+    // starts connecting immediately (no resolution-delay timer needed).
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(3),
+            result: DnsResult::Aaaa(Ok(vec![CDN_A_V6]), None),
+        },
+        now,
+    );
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(4),
+            result: DnsResult::A(Ok(vec![CDN_A_V4]), None),
+        },
+        now,
+    );
+
+    // First connection attempt (CDN_A with ECH) — before mismatch is known.
+    let first_attempt = match he.process_output(now) {
+        Some(Output::AttemptConnection { id, endpoint, .. }) => {
+            assert!(
+                endpoint.ech_config.is_some(),
+                "first attempt must carry ECH"
+            );
+            assert_eq!(
+                endpoint.address.ip(),
+                IpAddr::from(CDN_A_V6),
+                "first attempt must target CDN_A"
+            );
+            id
+        }
+        other => panic!("expected AttemptConnection, got {other:?}"),
+    };
+
+    // Origin AAAA arrives with a mismatching CNAME — CDN_B, not CDN_A.
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(1),
+            result: DnsResult::Aaaa(Ok(vec![ORIGIN_V6]), Some(CDN_B.into())),
+        },
+        now,
+    );
+
+    // The in-progress CDN_A attempt must NOT be cancelled.
+    let next = he.process_output(now);
+    assert!(
+        !matches!(&next, Some(Output::CancelConnection { id }) if *id == first_attempt),
+        "in-progress attempt must not be cancelled on CNAME mismatch; got {next:?}"
+    );
+
+    // Finish feeding remaining DNS results and let the machine run to completion.
+    he.process_input(
+        Input::DnsResult {
+            id: Id::from(2),
+            result: DnsResult::A(Ok(vec![ORIGIN_V4]), Some(CDN_B.into())),
+        },
+        now,
+    );
+
+    // Fail the in-progress CDN_A attempt to let the machine advance.
+    he.process_input(
+        Input::ConnectionResult {
+            id: first_attempt,
+            result: ConnectionResult::Failure("fail".to_string()),
+        },
+        now,
+    );
+
+    // Remaining attempts (driven by collect_attempts) must use origin addresses only.
+    let remaining = collect_attempts(&mut he, &mut now, None);
+    let cdn: HashSet<IpAddr> = HashSet::from([CDN_A_V6.into(), CDN_A_V4.into()]);
+    assert!(
+        attempted_addrs(&remaining).is_disjoint(&cdn),
+        "no further attempts must target the CDN after the CNAME mismatch"
+    );
+    assert!(
+        !any_ech(&remaining),
+        "subsequent attempts must not carry the dropped ECH record"
+    );
+}


### PR DESCRIPTION
Drop HTTPS records whose TargetName is inconsistent with the canonical name from the origin's A/AAAA resolution, preferring the origin's plain addresses (the CNAME) on mismatch. This avoids breaking the ECH handshake under dual-CDN steering, where the HTTPS record points at one CDN while the CNAME chain steers to another.

The canonical name rides on DnsResult::A / DnsResult::Aaaa. Filtering runs before ECH-based filtering, so dropping an inconsistent record lets the origin fallback re-engage. A ServiceInfo is kept if its TargetName matches the canonical name of either family; when none is reported, no filtering is applied. Comparison is case- and trailing-dot-insensitive.


---

//CC @dennisjackson see `#[test]`s at the end of `tests/https_rr_cname.rs` to get a high level overview.