### PR TITLE
test: share DNS-query assertion helpers across the suite

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -202,36 +202,28 @@ pub fn in_connection_result_ech_retry(id: Id) -> Input {
     }
 }
 
-pub fn out_send_dns_https(id: Id) -> Output {
+pub fn out_send_dns(id: Id, hostname: &str, record_type: DnsRecordType) -> Output {
     Output::SendDnsQuery {
         id,
-        hostname: HOSTNAME.into(),
-        record_type: DnsRecordType::Https,
+        hostname: hostname.into(),
+        record_type,
     }
+}
+
+pub fn out_send_dns_https(id: Id) -> Output {
+    out_send_dns(id, HOSTNAME, DnsRecordType::Https)
 }
 
 pub fn out_send_dns_aaaa(id: Id) -> Output {
-    Output::SendDnsQuery {
-        id,
-        hostname: HOSTNAME.into(),
-        record_type: DnsRecordType::Aaaa,
-    }
+    out_send_dns(id, HOSTNAME, DnsRecordType::Aaaa)
 }
 
 pub fn out_send_dns_svc1(id: Id) -> Output {
-    Output::SendDnsQuery {
-        id,
-        hostname: SVC1.into(),
-        record_type: DnsRecordType::Aaaa,
-    }
+    out_send_dns(id, SVC1, DnsRecordType::Aaaa)
 }
 
 pub fn out_send_dns_a(id: Id) -> Output {
-    Output::SendDnsQuery {
-        id,
-        hostname: HOSTNAME.into(),
-        record_type: DnsRecordType::A,
-    }
+    out_send_dns(id, HOSTNAME, DnsRecordType::A)
 }
 
 pub fn out_attempt_v6_h1_h2(id: Id) -> Output {
@@ -392,4 +384,26 @@ pub fn setup_with_config(config: NetworkConfig) -> (Instant, HappyEyeballs) {
     let now = Instant::now();
     let he = HappyEyeballs::new_with_network_config(HOSTNAME, PORT, config).unwrap();
     (now, he)
+}
+
+/// Assert that the next output is a DNS query for `hostname`/`record_type` with `id`.
+pub fn expect_query(
+    he: &mut HappyEyeballs,
+    now: Instant,
+    id: u64,
+    hostname: &str,
+    rt: DnsRecordType,
+) {
+    assert_eq!(
+        he.process_output(now),
+        Some(out_send_dns(Id::from(id), hostname, rt))
+    );
+}
+
+/// Assert the standard opening burst of DNS queries: HTTPS, AAAA, then A for the
+/// default `HOSTNAME` with ids 0, 1, 2.
+pub fn expect_initial_dns_queries(he: &mut HappyEyeballs, now: Instant) {
+    expect_query(he, now, 0, HOSTNAME, DnsRecordType::Https);
+    expect_query(he, now, 1, HOSTNAME, DnsRecordType::Aaaa);
+    expect_query(he, now, 2, HOSTNAME, DnsRecordType::A);
 }

--- a/tests/connection_attempts.rs
+++ b/tests/connection_attempts.rs
@@ -15,11 +15,9 @@ use happy_eyeballs::{
 fn ipv6_blackhole() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_positive(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -51,11 +49,9 @@ fn ipv6_blackhole() {
 fn connection_attempt_delay() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_positive_no_alpn(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -81,11 +77,9 @@ fn connection_attempt_delay() {
 fn never_try_same_attempt_twice() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_negative(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -111,11 +105,9 @@ fn never_try_same_attempt_twice() {
 fn successful_connection_cancels_others() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_positive_no_alpn(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -171,11 +163,9 @@ fn successful_connection_cancels_others() {
 fn failed_connection_tries_next_immediately() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_positive_no_alpn(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -205,11 +195,9 @@ fn failed_connection_tries_next_immediately() {
 fn successful_connection_emits_succeeded() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_positive_no_alpn(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -231,11 +219,9 @@ fn successful_connection_emits_succeeded() {
 fn succeeded_keeps_emitting_succeeded() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_positive_no_alpn(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -267,11 +253,9 @@ fn connection_attempt_delay_partial_elapsed() {
     });
 
     // Drive to first connection attempt at time T=now.
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_negative(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -300,11 +284,9 @@ fn connection_attempt_delay_partial_elapsed() {
 fn cancelled_connection_result_ignored() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_positive_no_alpn(Id::from(0))),
                 Some(out_resolution_delay()),

--- a/tests/failure.rs
+++ b/tests/failure.rs
@@ -12,11 +12,9 @@ use happy_eyeballs::{
 fn all_dns_failed() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_negative(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -39,11 +37,9 @@ fn all_dns_failed() {
 fn dns_partial_failure_then_connection_failed() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_negative(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -70,11 +66,9 @@ fn dns_partial_failure_then_connection_failed() {
 fn all_connections_failed() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_positive_no_alpn(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -136,11 +130,9 @@ fn ip_host_connection_failure() {
 fn first_connection_fails_second_succeeds() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_positive_no_alpn(Id::from(0))),
                 Some(out_resolution_delay()),

--- a/tests/hostname_resolution.rs
+++ b/tests/hostname_resolution.rs
@@ -21,13 +21,9 @@ fn expect_hints_move_on_with_timeout(
     https_input: Input,
     expected_attempt: Output,
 ) {
+    expect_initial_dns_queries(he, *now);
     he.expect(
-        vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
-            (Some(https_input), Some(out_resolution_delay())),
-        ],
+        vec![(Some(https_input), Some(out_resolution_delay()))],
         *now,
     );
     *now += RESOLUTION_DELAY;
@@ -55,14 +51,7 @@ fn initial_state() {
 fn sendig_dns_queries() {
     let (now, mut he) = setup();
 
-    he.expect(
-        vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
-        ],
-        now,
-    );
+    expect_initial_dns_queries(&mut he, now);
 }
 
 /// > Implementations SHOULD NOT wait for all answers to return before
@@ -73,11 +62,9 @@ fn sendig_dns_queries() {
 fn dont_wait_for_all_dns_answers() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_positive(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -188,11 +175,9 @@ fn move_on_non_timeout() {
         ] {
             let (now, mut he) = setup_with_config(test_case.address_family.clone());
 
+            expect_initial_dns_queries(&mut he, now);
             he.expect(
                 vec![
-                    (None, Some(out_send_dns_https(Id::from(0)))),
-                    (None, Some(out_send_dns_aaaa(Id::from(1)))),
-                    (None, Some(out_send_dns_a(Id::from(2)))),
                     (
                         Some(test_case.positive.clone()),
                         Some(out_resolution_delay()),
@@ -217,16 +202,12 @@ fn move_on_non_timeout() {
 fn move_on_timeout() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
-        vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_resolution_delay()),
-            ),
-        ],
+        vec![(
+            Some(in_dns_a_positive(Id::from(2))),
+            Some(out_resolution_delay()),
+        )],
         now,
     );
 
@@ -243,11 +224,9 @@ fn move_on_timeout() {
 fn resolution_delay_starts_after_other_response() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             // No other response received yet.
             (None, None),
             (
@@ -274,11 +253,9 @@ fn resolution_delay_starts_on_first_response() {
     const RESPONSE_DELAY: Duration = Duration::from_millis(10);
     let (start, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, start);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             // No other response received yet.
             (None, None),
         ],
@@ -329,16 +306,12 @@ fn resolution_delay_starts_on_first_response() {
 fn https_hints() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
-        vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
-            (
-                Some(in_dns_https_positive_v4_and_v6_hints(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-        ],
+        vec![(
+            Some(in_dns_https_positive_v4_and_v6_hints(Id::from(0))),
+            Some(out_resolution_delay()),
+        )],
         now,
     );
 
@@ -407,11 +380,9 @@ fn https_v4_hints_move_on_with_timeout() {
 fn resolution_delay_boundary() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             // HTTPS negative and A positive arrive at T; AAAA still pending.
             (
                 Some(in_dns_https_negative(Id::from(0))),
@@ -446,16 +417,12 @@ fn resolution_delay_boundary() {
 fn https_hints_still_query_a_aaaa() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
-        vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
-            (
-                Some(in_dns_https_positive_svc1(Id::from(0))),
-                Some(out_send_dns_svc1(Id::from(3))),
-            ),
-        ],
+        vec![(
+            Some(in_dns_https_positive_svc1(Id::from(0))),
+            Some(out_send_dns_svc1(Id::from(3))),
+        )],
         now,
     );
 }
@@ -464,11 +431,9 @@ fn https_hints_still_query_a_aaaa() {
 fn https_h3_upgrade_without_hints() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_aaaa_positive(Id::from(1))),
                 Some(out_resolution_delay()),
@@ -495,11 +460,9 @@ fn https_h3_disabled() {
         ..NetworkConfig::default()
     });
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_aaaa_positive(Id::from(1))),
                 Some(out_resolution_delay()),
@@ -517,11 +480,9 @@ fn https_h3_disabled() {
 fn multiple_ips_per_record() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_negative(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -631,11 +592,7 @@ fn single_stack_target_name_skips_disabled_address_family() {
         Case {
             ip: IpPreference::Ipv4Only,
             origin_dns_query: out_send_dns_a(Id::from(1)),
-            target_name_dns_query: Output::SendDnsQuery {
-                id: Id::from(2),
-                hostname: SVC1.into(),
-                record_type: DnsRecordType::A,
-            },
+            target_name_dns_query: out_send_dns(Id::from(2), SVC1, DnsRecordType::A),
         },
     ];
 

--- a/tests/https_records.rs
+++ b/tests/https_records.rs
@@ -21,27 +21,23 @@ fn ech_config_propagated_to_endpoint() {
     // HTTPS arrives with an ECH config and a v6 hint while AAAA and A are
     // still in-flight. After the resolution delay the hint is used, and the
     // ECH config must be carried onto the endpoint.
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
-        vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: HOSTNAME.into(),
-                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-                        ipv6_hints: vec![V6_ADDR],
-                        ipv4_hints: vec![],
-                        ech_config: Some(ech_config()),
-                        port: None,
-                    }])),
-                }),
-                Some(out_resolution_delay()),
-            ),
-        ],
+        vec![(
+            Some(Input::DnsResult {
+                id: Id::from(0),
+                result: DnsResult::Https(Ok(vec![ServiceInfo {
+                    priority: 1,
+                    target_name: HOSTNAME.into(),
+                    alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+                    ipv6_hints: vec![V6_ADDR],
+                    ipv4_hints: vec![],
+                    ech_config: Some(ech_config()),
+                    port: None,
+                }])),
+            }),
+            Some(out_resolution_delay()),
+        )],
         now,
     );
 
@@ -116,11 +112,9 @@ fn hints_discarded_on_negative_answer() {
     for case in cases {
         let (mut now, mut he) = setup_with_config(case.config);
 
+        expect_initial_dns_queries(&mut he, now);
         he.expect(
             vec![
-                (None, Some(out_send_dns_https(Id::from(0)))),
-                (None, Some(out_send_dns_aaaa(Id::from(1)))),
-                (None, Some(out_send_dns_a(Id::from(2)))),
                 (Some(case.first_arrives), Some(out_resolution_delay())),
                 (Some(case.second_arrives), Some(out_resolution_delay())),
                 (
@@ -163,11 +157,9 @@ fn ech_disabled() {
         ..NetworkConfig::default()
     });
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_a_negative(Id::from(2))),
                 Some(out_resolution_delay()),
@@ -224,11 +216,9 @@ fn ech_disabled() {
 fn ech_config_from_https_applies_to_aaaa() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
@@ -265,11 +255,9 @@ fn ech_config_from_https_applies_to_aaaa() {
 fn multiple_target_names() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             // HTTPS response with a different target name
             (
                 Some(in_dns_https_positive_svc1(Id::from(0))),
@@ -319,11 +307,9 @@ fn partial_ech_two_service_infos() {
 
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
@@ -349,19 +335,11 @@ fn partial_ech_two_service_infos() {
                     ])),
                 }),
                 // Only SVC1 gets DNS queries — SVC2 is skipped (no ECH)
-                Some(Output::SendDnsQuery {
-                    id: Id::from(3),
-                    hostname: SVC1.into(),
-                    record_type: DnsRecordType::Aaaa,
-                }),
+                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
             ),
             (
                 None,
-                Some(Output::SendDnsQuery {
-                    id: Id::from(4),
-                    hostname: SVC1.into(),
-                    record_type: DnsRecordType::A,
-                }),
+                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
             ),
             (None, Some(out_resolution_delay())),
             // HOSTNAME AAAA positive -> move-on criteria met, but SVC1 has no
@@ -442,11 +420,9 @@ fn both_service_infos_have_ech_no_origin_fallback() {
 
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
@@ -472,35 +448,19 @@ fn both_service_infos_have_ech_no_origin_fallback() {
                     ])),
                 }),
                 // Both SVC1 and SVC2 get DNS queries (both have ECH)
-                Some(Output::SendDnsQuery {
-                    id: Id::from(3),
-                    hostname: SVC1.into(),
-                    record_type: DnsRecordType::Aaaa,
-                }),
+                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
             ),
             (
                 None,
-                Some(Output::SendDnsQuery {
-                    id: Id::from(4),
-                    hostname: SVC1.into(),
-                    record_type: DnsRecordType::A,
-                }),
+                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
             ),
             (
                 None,
-                Some(Output::SendDnsQuery {
-                    id: Id::from(5),
-                    hostname: SVC2.into(),
-                    record_type: DnsRecordType::Aaaa,
-                }),
+                Some(out_send_dns(Id::from(5), SVC2, DnsRecordType::Aaaa)),
             ),
             (
                 None,
-                Some(Output::SendDnsQuery {
-                    id: Id::from(6),
-                    hostname: SVC2.into(),
-                    record_type: DnsRecordType::A,
-                }),
+                Some(out_send_dns(Id::from(6), SVC2, DnsRecordType::A)),
             ),
             (None, Some(out_resolution_delay())),
             // HOSTNAME AAAA/A positive — but fallback will be skipped (no ECH)
@@ -622,11 +582,9 @@ fn partial_ech_with_alt_svc() {
     };
     let (mut now, mut he) = setup_with_config(config);
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
@@ -652,19 +610,11 @@ fn partial_ech_with_alt_svc() {
                     ])),
                 }),
                 // Only SVC1 gets DNS queries — SVC2 skipped (no ECH)
-                Some(Output::SendDnsQuery {
-                    id: Id::from(3),
-                    hostname: SVC1.into(),
-                    record_type: DnsRecordType::Aaaa,
-                }),
+                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
             ),
             (
                 None,
-                Some(Output::SendDnsQuery {
-                    id: Id::from(4),
-                    hostname: SVC1.into(),
-                    record_type: DnsRecordType::A,
-                }),
+                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
             ),
             (None, Some(out_resolution_delay())),
             // HOSTNAME AAAA/A positive
@@ -732,27 +682,23 @@ mod https_port_svcparam_overrides_port_for {
         // HTTPS arrives with port=8443 while AAAA and A are still in-flight.
         // After the resolution delay the hint is used; the connection attempt
         // must use 8443, not the authority port 443. IPv6 is preferred.
+        expect_initial_dns_queries(&mut he, now);
         he.expect(
-            vec![
-                (None, Some(out_send_dns_https(Id::from(0)))),
-                (None, Some(out_send_dns_aaaa(Id::from(1)))),
-                (None, Some(out_send_dns_a(Id::from(2)))),
-                (
-                    Some(Input::DnsResult {
-                        id: Id::from(0),
-                        result: DnsResult::Https(Ok(vec![ServiceInfo {
-                            priority: 1,
-                            target_name: HOSTNAME.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-                            ipv6_hints: vec![V6_ADDR],
-                            ipv4_hints,
-                            ech_config: None,
-                            port: Some(CUSTOM_PORT),
-                        }])),
-                    }),
-                    Some(out_resolution_delay()),
-                ),
-            ],
+            vec![(
+                Some(Input::DnsResult {
+                    id: Id::from(0),
+                    result: DnsResult::Https(Ok(vec![ServiceInfo {
+                        priority: 1,
+                        target_name: HOSTNAME.into(),
+                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
+                        ipv6_hints: vec![V6_ADDR],
+                        ipv4_hints,
+                        ech_config: None,
+                        port: Some(CUSTOM_PORT),
+                    }])),
+                }),
+                Some(out_resolution_delay()),
+            )],
             now,
         );
 
@@ -780,11 +726,9 @@ mod https_port_svcparam_overrides_port_for {
 fn https_port_svcparam_applies_to_resolved_a_and_aaaa() {
     let (now, mut he) = setup(); // constructed with PORT (443)
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             // HTTPS record with port=8443, no hints
             (
                 Some(Input::DnsResult {
@@ -824,11 +768,9 @@ fn https_port_svcparam_applies_to_resolved_a_and_aaaa() {
 fn https_port_svcparam_applies_but_fallbacks_follow() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             // HTTPS record with port=8443, no hints
             (
                 Some(Input::DnsResult {
@@ -912,11 +854,9 @@ fn https_two_service_infos_with_different_ports() {
             }
         };
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             // Two ServiceInfo records; the lower priority number wins first.
             (
                 Some(Input::DnsResult {
@@ -994,11 +934,9 @@ fn https_two_service_infos_with_different_ports() {
 fn no_default_alpn() {
     let (now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_positive(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -1045,11 +983,9 @@ fn no_default_alpn() {
 fn https_svc1_addresses_trigger_additional_attempts() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
@@ -1074,19 +1010,11 @@ fn https_svc1_addresses_trigger_additional_attempts() {
                         },
                     ])),
                 }),
-                Some(Output::SendDnsQuery {
-                    id: Id::from(3),
-                    hostname: SVC1.into(),
-                    record_type: DnsRecordType::Aaaa,
-                }),
+                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
             ),
             (
                 None,
-                Some(Output::SendDnsQuery {
-                    id: Id::from(4),
-                    hostname: SVC1.into(),
-                    record_type: DnsRecordType::A,
-                }),
+                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
             ),
             (None, Some(out_resolution_delay())),
             (
@@ -1169,11 +1097,9 @@ fn https_port_takes_precedence_over_alt_svc_port() {
     };
     let (mut now, mut he) = setup_with_config(config);
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             // HTTPS record with port=8443
             (
                 Some(Input::DnsResult {
@@ -1281,11 +1207,9 @@ fn https_port_takes_precedence_over_alt_svc_port() {
 fn target_name_redirect_addresses_used_in_connection_attempts() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             // HTTPS response redirects to SVC1 (different target name, no hints)
             (
                 Some(Input::DnsResult {
@@ -1301,19 +1225,11 @@ fn target_name_redirect_addresses_used_in_connection_attempts() {
                     }])),
                 }),
                 // Follow-up DNS for the redirected target name
-                Some(Output::SendDnsQuery {
-                    id: Id::from(3),
-                    hostname: SVC1.into(),
-                    record_type: DnsRecordType::Aaaa,
-                }),
+                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
             ),
             (
                 None,
-                Some(Output::SendDnsQuery {
-                    id: Id::from(4),
-                    hostname: SVC1.into(),
-                    record_type: DnsRecordType::A,
-                }),
+                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
             ),
             (None, Some(out_resolution_delay())),
             // SVC1 AAAA positive → move-on criteria met, first attempt uses
@@ -1393,11 +1309,9 @@ fn target_name_redirect_addresses_used_in_connection_attempts() {
 fn https_fallback_uses_default_http_versions() {
     let (mut now, mut he) = setup();
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             // HTTPS record with port=8443, alpn=h3 only
             (
                 Some(Input::DnsResult {
@@ -1446,11 +1360,9 @@ fn ech_retry_same_endpoint() {
 
     let new_ech_config = EchConfig::new(vec![10, 20, 30, 40, 50]);
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
@@ -1514,11 +1426,9 @@ fn ech_retry_without_ech_sets_flag() {
 
     let empty_ech_config = EchConfig::new(vec![]);
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
@@ -1581,11 +1491,9 @@ fn ech_retry_no_infinite_loop() {
     let retry_ech_config = EchConfig::new(vec![10, 20, 30, 40, 50]);
     let retry_ech_config_2 = EchConfig::new(vec![60, 70, 80]);
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),

--- a/tests/network_config.rs
+++ b/tests/network_config.rs
@@ -54,11 +54,9 @@ fn alt_svc_used_immediately() {
     let mut he = HappyEyeballs::new_with_network_config(HOSTNAME, PORT, config).unwrap();
 
     // Alt-svc with H3 should make H3 available even without HTTPS DNS response
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_negative(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -93,11 +91,9 @@ fn alt_svc_with_port() {
     };
     let (mut now, mut he) = setup_with_config(config);
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
         vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
             (
                 Some(in_dns_https_negative(Id::from(0))),
                 Some(out_resolution_delay()),
@@ -226,19 +222,15 @@ fn custom_delays() {
         ..NetworkConfig::default()
     });
 
+    expect_initial_dns_queries(&mut he, now);
     he.expect(
-        vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                // Should use the custom resolution delay, not the default 50ms.
-                Some(Output::Timer {
-                    duration: custom_resolution_delay,
-                }),
-            ),
-        ],
+        vec![(
+            Some(in_dns_a_positive(Id::from(2))),
+            // Should use the custom resolution delay, not the default 50ms.
+            Some(Output::Timer {
+                duration: custom_resolution_delay,
+            }),
+        )],
         now,
     );
 

--- a/tests/type_impls.rs
+++ b/tests/type_impls.rs
@@ -76,16 +76,12 @@ fn happy_eyeballs_debug() {
 
     // Drive through DNS queries, feed HTTPS+ECH and AAAA to get a connection
     // attempt that carries ECH config.
+    expect_initial_dns_queries(&mut he2, now2);
     he2.expect(
-        vec![
-            (None, Some(out_send_dns_https(Id::from(0)))),
-            (None, Some(out_send_dns_aaaa(Id::from(1)))),
-            (None, Some(out_send_dns_a(Id::from(2)))),
-            (
-                Some(in_dns_https_positive_ech(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-        ],
+        vec![(
+            Some(in_dns_https_positive_ech(Id::from(0))),
+            Some(out_resolution_delay()),
+        )],
         now2,
     );
 


### PR DESCRIPTION
Promote the `expect_query` helper into `tests/common` and introduce two related helpers to cut boilerplate in the integration tests:

- `out_send_dns(id, hostname, record_type)`: generic builder for a `SendDnsQuery` output. The fixed-hostname builders now delegate to it, and the inline `Output::SendDnsQuery { .. }` literals (SVC1/SVC2 target queries) use it directly.
- `expect_query(he, now, id, hostname, rt)`: drive one `process_output` and assert it is the expected DNS query.
- `expect_initial_dns_queries(he, now)`: assert the standard opening HTTPS/AAAA/A burst (ids 0, 1, 2) for the default hostname, which was repeated ~50 times.

No behavioral change to the tests; net ~160 fewer lines.