### PR TITLE
test: add service_info helper and apply it across the suite

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
 use std::{
-    collections::HashSet,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::Instant,
 };
@@ -25,6 +24,58 @@ pub const ECH_CONFIG_BYTES: &[u8] = &[1, 2, 3, 4, 5];
 
 pub fn ech_config() -> EchConfig {
     EchConfig::new(ECH_CONFIG_BYTES.to_vec())
+}
+
+/// Build a [`ServiceInfo`] from the fields tests usually vary: priority, target
+/// name, and ALPN versions. The remaining fields (hints, ECH, port) default to
+/// empty/none; set them with the chainable [`ServiceInfoExt`] methods, e.g.
+/// `service_info(1, SVC1, &[HttpVersion::H3]).ech().port(8443)`.
+pub fn service_info(priority: u16, target_name: &str, alpns: &[HttpVersion]) -> ServiceInfo {
+    ServiceInfo {
+        priority,
+        target_name: target_name.into(),
+        alpn_http_versions: alpns.iter().copied().collect(),
+        ipv6_hints: vec![],
+        ipv4_hints: vec![],
+        ech_config: None,
+        port: None,
+    }
+}
+
+/// Chainable setters for the non-default [`ServiceInfo`] fields, so tests can
+/// build records without spelling out the defaults, e.g.
+/// `service_info(1, SVC1, &[HttpVersion::H3]).ech().port(9443)`.
+pub trait ServiceInfoExt {
+    /// Attach the default test ECH config ([`ech_config`]).
+    fn ech(self) -> Self;
+    /// Attach a specific ECH config.
+    fn ech_with(self, ech: EchConfig) -> Self;
+    fn port(self, port: u16) -> Self;
+    fn ipv6_hints(self, hints: Vec<Ipv6Addr>) -> Self;
+    fn ipv4_hints(self, hints: Vec<Ipv4Addr>) -> Self;
+}
+
+impl ServiceInfoExt for ServiceInfo {
+    fn ech(mut self) -> Self {
+        self.ech_config = Some(ech_config());
+        self
+    }
+    fn ech_with(mut self, ech: EchConfig) -> Self {
+        self.ech_config = Some(ech);
+        self
+    }
+    fn port(mut self, port: u16) -> Self {
+        self.port = Some(port);
+        self
+    }
+    fn ipv6_hints(mut self, hints: Vec<Ipv6Addr>) -> Self {
+        self.ipv6_hints = hints;
+        self
+    }
+    fn ipv4_hints(mut self, hints: Vec<Ipv4Addr>) -> Self {
+        self.ipv4_hints = hints;
+        self
+    }
 }
 
 pub trait HappyEyeballsExt {
@@ -62,60 +113,38 @@ impl HappyEyeballsExt for HappyEyeballs {
 pub fn in_dns_https_positive(id: Id) -> Input {
     Input::DnsResult {
         id,
-        result: DnsResult::Https(Ok(vec![ServiceInfo {
-            priority: 1,
-            target_name: HOSTNAME.into(),
-            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-            ipv6_hints: vec![],
-            ipv4_hints: vec![],
-            ech_config: None,
-            port: None,
-        }])),
+        result: DnsResult::Https(Ok(vec![service_info(
+            1,
+            HOSTNAME,
+            &[HttpVersion::H3, HttpVersion::H2],
+        )])),
     }
 }
 
 pub fn in_dns_https_positive_ech(id: Id) -> Input {
     Input::DnsResult {
         id,
-        result: DnsResult::Https(Ok(vec![ServiceInfo {
-            priority: 1,
-            target_name: HOSTNAME.into(),
-            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-            ipv6_hints: vec![],
-            ipv4_hints: vec![],
-            ech_config: Some(ech_config()),
-            port: None,
-        }])),
+        result: DnsResult::Https(Ok(vec![
+            service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).ech(),
+        ])),
     }
 }
 
 pub fn in_dns_https_positive_no_alpn(id: Id) -> Input {
     Input::DnsResult {
         id,
-        result: DnsResult::Https(Ok(vec![ServiceInfo {
-            priority: 1,
-            target_name: HOSTNAME.into(),
-            alpn_http_versions: HashSet::new(),
-            ipv6_hints: vec![],
-            ipv4_hints: vec![],
-            ech_config: None,
-            port: None,
-        }])),
+        result: DnsResult::Https(Ok(vec![service_info(1, HOSTNAME, &[])])),
     }
 }
 
 fn in_dns_https_with_hints(id: Id, ipv4_hints: Vec<Ipv4Addr>, ipv6_hints: Vec<Ipv6Addr>) -> Input {
     Input::DnsResult {
         id,
-        result: DnsResult::Https(Ok(vec![ServiceInfo {
-            priority: 1,
-            target_name: HOSTNAME.into(),
-            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-            ipv4_hints,
-            ipv6_hints,
-            ech_config: None,
-            port: None,
-        }])),
+        result: DnsResult::Https(Ok(vec![
+            service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
+                .ipv4_hints(ipv4_hints)
+                .ipv6_hints(ipv6_hints),
+        ])),
     }
 }
 
@@ -134,15 +163,9 @@ pub fn in_dns_https_positive_v4_and_v6_hints(id: Id) -> Input {
 pub fn in_dns_https_positive_svc1(id: Id) -> Input {
     Input::DnsResult {
         id,
-        result: DnsResult::Https(Ok(vec![ServiceInfo {
-            priority: 1,
-            target_name: SVC1.into(),
-            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-            ipv6_hints: vec![V6_ADDR_2],
-            ipv4_hints: vec![],
-            ech_config: None,
-            port: None,
-        }])),
+        result: DnsResult::Https(Ok(vec![
+            service_info(1, SVC1, &[HttpVersion::H3, HttpVersion::H2]).ipv6_hints(vec![V6_ADDR_2]),
+        ])),
     }
 }
 

--- a/tests/https_records.rs
+++ b/tests/https_records.rs
@@ -3,15 +3,12 @@
 mod common;
 use common::*;
 
-use std::{
-    collections::HashSet,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use happy_eyeballs::{
     AltSvc, CONNECTION_ATTEMPT_DELAY, ConnectionAttemptHttpVersions, ConnectionResult,
     DnsRecordType, DnsResult, EchConfig, Endpoint, FailureReason, HttpVersion, Id, Input,
-    IpPreference, NetworkConfig, Output, RESOLUTION_DELAY, ServiceInfo,
+    IpPreference, NetworkConfig, Output, RESOLUTION_DELAY,
 };
 
 #[test]
@@ -26,15 +23,11 @@ fn ech_config_propagated_to_endpoint() {
         vec![(
             Some(Input::DnsResult {
                 id: Id::from(0),
-                result: DnsResult::Https(Ok(vec![ServiceInfo {
-                    priority: 1,
-                    target_name: HOSTNAME.into(),
-                    alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-                    ipv6_hints: vec![V6_ADDR],
-                    ipv4_hints: vec![],
-                    ech_config: Some(ech_config()),
-                    port: None,
-                }])),
+                result: DnsResult::Https(Ok(vec![
+                    service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
+                        .ipv6_hints(vec![V6_ADDR])
+                        .ech(),
+                ])),
             }),
             Some(out_resolution_delay()),
         )],
@@ -120,15 +113,11 @@ fn hints_discarded_on_negative_answer() {
                 (
                     Some(Input::DnsResult {
                         id: Id::from(0),
-                        result: DnsResult::Https(Ok(vec![ServiceInfo {
-                            priority: 1,
-                            target_name: HOSTNAME.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-                            ipv6_hints: case.ipv6_hints,
-                            ipv4_hints: case.ipv4_hints,
-                            ech_config: None,
-                            port: None,
-                        }])),
+                        result: DnsResult::Https(Ok(vec![
+                            service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
+                                .ipv6_hints(case.ipv6_hints)
+                                .ipv4_hints(case.ipv4_hints),
+                        ])),
                     }),
                     Some(case.attempt_1),
                 ),
@@ -171,16 +160,12 @@ fn ech_disabled() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: HOSTNAME.into(),
-                        // Only H3 in ALPN — fallback bucket uses H2OrH1 by default.
-                        alpn_http_versions: HashSet::from([HttpVersion::H3]),
-                        ipv6_hints: vec![V6_ADDR],
-                        ipv4_hints: vec![],
-                        ech_config: Some(ech_config()),
-                        port: None,
-                    }])),
+                    // Only H3 in ALPN — fallback bucket uses H2OrH1 by default.
+                    result: DnsResult::Https(Ok(vec![
+                        service_info(1, HOSTNAME, &[HttpVersion::H3])
+                            .ipv6_hints(vec![V6_ADDR])
+                            .ech(),
+                    ])),
                 }),
                 // HTTPS bucket: V6:H3, but ECH stripped.
                 Some(Output::AttemptConnection {
@@ -222,15 +207,9 @@ fn ech_config_from_https_applies_to_aaaa() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: HOSTNAME.into(),
-                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-                        ipv6_hints: vec![],
-                        ipv4_hints: vec![],
-                        ech_config: Some(ech_config()),
-                        port: None,
-                    }])),
+                    result: DnsResult::Https(Ok(vec![
+                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).ech(),
+                    ])),
                 }),
                 Some(out_resolution_delay()),
             ),
@@ -314,24 +293,10 @@ fn partial_ech_two_service_infos() {
                 Some(Input::DnsResult {
                     id: Id::from(0),
                     result: DnsResult::Https(Ok(vec![
-                        ServiceInfo {
-                            priority: 1,
-                            target_name: SVC1.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H3]),
-                            ipv6_hints: vec![],
-                            ipv4_hints: vec![],
-                            ech_config: Some(ech_config()),
-                            port: Some(SVC1_PORT),
-                        },
-                        ServiceInfo {
-                            priority: 2,
-                            target_name: SVC2.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H2]),
-                            ipv6_hints: vec![],
-                            ipv4_hints: vec![],
-                            ech_config: None,
-                            port: Some(SVC2_PORT),
-                        },
+                        service_info(1, SVC1, &[HttpVersion::H3])
+                            .ech()
+                            .port(SVC1_PORT),
+                        service_info(2, SVC2, &[HttpVersion::H2]).port(SVC2_PORT),
                     ])),
                 }),
                 // Only SVC1 gets DNS queries — SVC2 is skipped (no ECH)
@@ -427,24 +392,12 @@ fn both_service_infos_have_ech_no_origin_fallback() {
                 Some(Input::DnsResult {
                     id: Id::from(0),
                     result: DnsResult::Https(Ok(vec![
-                        ServiceInfo {
-                            priority: 1,
-                            target_name: SVC1.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H3]),
-                            ipv6_hints: vec![],
-                            ipv4_hints: vec![],
-                            ech_config: Some(ech_config()),
-                            port: Some(SVC1_PORT),
-                        },
-                        ServiceInfo {
-                            priority: 2,
-                            target_name: SVC2.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H2]),
-                            ipv6_hints: vec![],
-                            ipv4_hints: vec![],
-                            ech_config: Some(ech_config()),
-                            port: Some(SVC2_PORT),
-                        },
+                        service_info(1, SVC1, &[HttpVersion::H3])
+                            .ech()
+                            .port(SVC1_PORT),
+                        service_info(2, SVC2, &[HttpVersion::H2])
+                            .ech()
+                            .port(SVC2_PORT),
                     ])),
                 }),
                 // Both SVC1 and SVC2 get DNS queries (both have ECH)
@@ -589,24 +542,10 @@ fn partial_ech_with_alt_svc() {
                 Some(Input::DnsResult {
                     id: Id::from(0),
                     result: DnsResult::Https(Ok(vec![
-                        ServiceInfo {
-                            priority: 1,
-                            target_name: SVC1.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H3]),
-                            ipv6_hints: vec![],
-                            ipv4_hints: vec![],
-                            ech_config: Some(ech_config()),
-                            port: Some(SVC1_PORT),
-                        },
-                        ServiceInfo {
-                            priority: 2,
-                            target_name: SVC2.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H2]),
-                            ipv6_hints: vec![],
-                            ipv4_hints: vec![],
-                            ech_config: None,
-                            port: Some(SVC2_PORT),
-                        },
+                        service_info(1, SVC1, &[HttpVersion::H3])
+                            .ech()
+                            .port(SVC1_PORT),
+                        service_info(2, SVC2, &[HttpVersion::H2]).port(SVC2_PORT),
                     ])),
                 }),
                 // Only SVC1 gets DNS queries — SVC2 skipped (no ECH)
@@ -687,15 +626,12 @@ mod https_port_svcparam_overrides_port_for {
             vec![(
                 Some(Input::DnsResult {
                     id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: HOSTNAME.into(),
-                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-                        ipv6_hints: vec![V6_ADDR],
-                        ipv4_hints,
-                        ech_config: None,
-                        port: Some(CUSTOM_PORT),
-                    }])),
+                    result: DnsResult::Https(Ok(vec![
+                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
+                            .ipv6_hints(vec![V6_ADDR])
+                            .ipv4_hints(ipv4_hints)
+                            .port(CUSTOM_PORT),
+                    ])),
                 }),
                 Some(out_resolution_delay()),
             )],
@@ -733,15 +669,10 @@ fn https_port_svcparam_applies_to_resolved_a_and_aaaa() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: HOSTNAME.into(),
-                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-                        ipv6_hints: vec![],
-                        ipv4_hints: vec![],
-                        ech_config: None,
-                        port: Some(CUSTOM_PORT),
-                    }])),
+                    result: DnsResult::Https(Ok(vec![
+                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
+                            .port(CUSTOM_PORT),
+                    ])),
                 }),
                 Some(out_resolution_delay()),
             ),
@@ -775,15 +706,10 @@ fn https_port_svcparam_applies_but_fallbacks_follow() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: HOSTNAME.into(),
-                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-                        ipv6_hints: vec![],
-                        ipv4_hints: vec![],
-                        ech_config: None,
-                        port: Some(CUSTOM_PORT),
-                    }])),
+                    result: DnsResult::Https(Ok(vec![
+                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
+                            .port(CUSTOM_PORT),
+                    ])),
                 }),
                 Some(out_resolution_delay()),
             ),
@@ -862,24 +788,8 @@ fn https_two_service_infos_with_different_ports() {
                 Some(Input::DnsResult {
                     id: Id::from(0),
                     result: DnsResult::Https(Ok(vec![
-                        ServiceInfo {
-                            priority: 1,
-                            target_name: HOSTNAME.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-                            ipv6_hints: vec![],
-                            ipv4_hints: vec![],
-                            ech_config: None,
-                            port: Some(PORT_1),
-                        },
-                        ServiceInfo {
-                            priority: 2,
-                            target_name: HOSTNAME.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-                            ipv6_hints: vec![],
-                            ipv4_hints: vec![],
-                            ech_config: None,
-                            port: Some(PORT_2),
-                        },
+                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).port(PORT_1),
+                        service_info(2, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).port(PORT_2),
                     ])),
                 }),
                 Some(out_resolution_delay()),
@@ -990,24 +900,8 @@ fn https_svc1_addresses_trigger_additional_attempts() {
                 Some(Input::DnsResult {
                     id: Id::from(0),
                     result: DnsResult::Https(Ok(vec![
-                        ServiceInfo {
-                            priority: 1,
-                            target_name: HOSTNAME.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H2, HttpVersion::H3]),
-                            ipv6_hints: vec![],
-                            ipv4_hints: vec![],
-                            ech_config: None,
-                            port: None,
-                        },
-                        ServiceInfo {
-                            priority: 2,
-                            target_name: SVC1.into(),
-                            alpn_http_versions: HashSet::from([HttpVersion::H2, HttpVersion::H3]),
-                            ipv6_hints: vec![],
-                            ipv4_hints: vec![],
-                            ech_config: None,
-                            port: None,
-                        },
+                        service_info(1, HOSTNAME, &[HttpVersion::H2, HttpVersion::H3]),
+                        service_info(2, SVC1, &[HttpVersion::H2, HttpVersion::H3]),
                     ])),
                 }),
                 Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
@@ -1104,15 +998,10 @@ fn https_port_takes_precedence_over_alt_svc_port() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: HOSTNAME.into(),
-                        alpn_http_versions: HashSet::from([HttpVersion::H3, HttpVersion::H2]),
-                        ipv6_hints: vec![],
-                        ipv4_hints: vec![],
-                        ech_config: None,
-                        port: Some(HTTPS_PORT),
-                    }])),
+                    result: DnsResult::Https(Ok(vec![
+                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
+                            .port(HTTPS_PORT),
+                    ])),
                 }),
                 Some(out_resolution_delay()),
             ),
@@ -1214,15 +1103,7 @@ fn target_name_redirect_addresses_used_in_connection_attempts() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: SVC1.into(),
-                        alpn_http_versions: HashSet::from([HttpVersion::H3]),
-                        ipv6_hints: vec![],
-                        ipv4_hints: vec![],
-                        ech_config: None,
-                        port: None,
-                    }])),
+                    result: DnsResult::Https(Ok(vec![service_info(1, SVC1, &[HttpVersion::H3])])),
                 }),
                 // Follow-up DNS for the redirected target name
                 Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
@@ -1316,15 +1197,9 @@ fn https_fallback_uses_default_http_versions() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: HOSTNAME.into(),
-                        alpn_http_versions: HashSet::from([HttpVersion::H3]),
-                        ipv6_hints: vec![],
-                        ipv4_hints: vec![],
-                        ech_config: None,
-                        port: Some(CUSTOM_PORT),
-                    }])),
+                    result: DnsResult::Https(Ok(vec![
+                        service_info(1, HOSTNAME, &[HttpVersion::H3]).port(CUSTOM_PORT),
+                    ])),
                 }),
                 Some(out_resolution_delay()),
             ),
@@ -1366,15 +1241,9 @@ fn ech_retry_same_endpoint() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: HOSTNAME.into(),
-                        alpn_http_versions: HashSet::from([HttpVersion::H2]),
-                        ipv6_hints: vec![],
-                        ipv4_hints: vec![],
-                        ech_config: Some(ech_config()),
-                        port: None,
-                    }])),
+                    result: DnsResult::Https(Ok(vec![
+                        service_info(1, HOSTNAME, &[HttpVersion::H2]).ech(),
+                    ])),
                 }),
                 Some(out_resolution_delay()),
             ),
@@ -1432,15 +1301,9 @@ fn ech_retry_without_ech_sets_flag() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: HOSTNAME.into(),
-                        alpn_http_versions: HashSet::from([HttpVersion::H2]),
-                        ipv6_hints: vec![],
-                        ipv4_hints: vec![],
-                        ech_config: Some(ech_config()),
-                        port: None,
-                    }])),
+                    result: DnsResult::Https(Ok(vec![
+                        service_info(1, HOSTNAME, &[HttpVersion::H2]).ech(),
+                    ])),
                 }),
                 Some(out_resolution_delay()),
             ),
@@ -1497,15 +1360,9 @@ fn ech_retry_no_infinite_loop() {
             (
                 Some(Input::DnsResult {
                     id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![ServiceInfo {
-                        priority: 1,
-                        target_name: HOSTNAME.into(),
-                        alpn_http_versions: HashSet::from([HttpVersion::H2]),
-                        ipv6_hints: vec![],
-                        ipv4_hints: vec![],
-                        ech_config: Some(ech_config()),
-                        port: None,
-                    }])),
+                    result: DnsResult::Https(Ok(vec![
+                        service_info(1, HOSTNAME, &[HttpVersion::H2]).ech(),
+                    ])),
                 }),
                 Some(out_resolution_delay()),
             ),

--- a/tests/https_rr_cname.rs
+++ b/tests/https_rr_cname.rs
@@ -18,7 +18,7 @@ use std::{
 
 use happy_eyeballs::{
     ConnectionResult, DnsRecordType, DnsResult, Endpoint, HappyEyeballs, HttpVersion, Id, Input,
-    NetworkConfig, Output, ServiceInfo,
+    NetworkConfig, Output,
 };
 
 /// HTTPS record `TargetName`: a CDN distinct from the origin, carrying ECH.
@@ -35,15 +35,9 @@ const CDN_A_V4: Ipv4Addr = V4_ADDR_2;
 
 /// A single ECH-bearing HTTPS record pointing at `target`.
 fn https_ech_record(target: &str) -> DnsResult {
-    DnsResult::Https(Ok(vec![ServiceInfo {
-        priority: 1,
-        target_name: target.into(),
-        alpn_http_versions: HashSet::from([HttpVersion::H2, HttpVersion::H3]),
-        ipv6_hints: vec![],
-        ipv4_hints: vec![],
-        ech_config: Some(ech_config()),
-        port: None,
-    }]))
+    DnsResult::Https(Ok(vec![
+        service_info(1, target, &[HttpVersion::H2, HttpVersion::H3]).ech(),
+    ]))
 }
 
 /// Case- and trailing-dot-insensitive name comparison, matching the crate's


### PR DESCRIPTION
Introduce service_info(priority, target, alpns) plus a chainable ServiceInfoExt trait (.ech(), .ech_with(), .port(), .ipv6_hints(), .ipv4_hints()), and replace the verbose ServiceInfo { ... } literals throughout the suite (common/mod.rs, https_records.rs, https_rr_cname.rs). type_impls.rs is left as explicit literals since it tests Debug formatting field-by-field.