### PR TITLE
test: decouple input from output in the test driver

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -90,7 +90,11 @@ pub trait HappyEyeballsExt {
     fn expect_all(&mut self, expected: impl IntoIterator<Item = Output>, now: Instant);
     /// Assert that the state machine has no further output to produce.
     fn expect_idle(&mut self, now: Instant);
-    fn expect_connection_attempts(&mut self, connections: Vec<Output>, now: &mut Instant);
+    fn expect_connection_attempts(
+        &mut self,
+        connections: impl IntoIterator<Item = Output>,
+        now: &mut Instant,
+    );
 }
 
 impl HappyEyeballsExt for HappyEyeballs {
@@ -112,7 +116,11 @@ impl HappyEyeballsExt for HappyEyeballs {
         assert_eq!(None, self.process_output(now));
     }
 
-    fn expect_connection_attempts(&mut self, connections: Vec<Output>, now: &mut Instant) {
+    fn expect_connection_attempts(
+        &mut self,
+        connections: impl IntoIterator<Item = Output>,
+        now: &mut Instant,
+    ) {
         for conn in connections {
             *now += CONNECTION_ATTEMPT_DELAY;
             self.expect(conn, *now);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -79,35 +79,47 @@ impl ServiceInfoExt for ServiceInfo {
     }
 }
 
+/// Test-only driver methods on [`HappyEyeballs`]. All methods take `now` last.
 pub trait HappyEyeballsExt {
-    fn expect(&mut self, input_output: Vec<(Option<Input>, Option<Output>)>, now: Instant);
-    fn expect_connection_attempts(&mut self, now: &mut Instant, connections: Vec<Output>);
+    /// Feed a single input into the state machine.
+    fn input(&mut self, input: Input, now: Instant);
+    /// Assert that the next output equals `expected`.
+    fn expect(&mut self, expected: Output, now: Instant);
+    /// Assert that the next outputs equal `expected`, in order. Convenience for
+    /// a run of consecutive outputs emitted at the same `now`.
+    fn expect_all(&mut self, expected: impl IntoIterator<Item = Output>, now: Instant);
+    /// Assert that the state machine has no further output to produce.
+    fn expect_idle(&mut self, now: Instant);
+    fn expect_connection_attempts(&mut self, connections: Vec<Output>, now: &mut Instant);
 }
 
 impl HappyEyeballsExt for HappyEyeballs {
-    fn expect(&mut self, input_output: Vec<(Option<Input>, Option<Output>)>, now: Instant) {
-        for (input, expected_output) in input_output {
-            if let Some(input) = input {
-                self.process_input(input, now);
-            }
-            let output = self.process_output(now);
-            assert_eq!(expected_output, output);
+    fn input(&mut self, input: Input, now: Instant) {
+        self.process_input(input, now);
+    }
+
+    fn expect(&mut self, expected: Output, now: Instant) {
+        assert_eq!(Some(expected), self.process_output(now));
+    }
+
+    fn expect_all(&mut self, expected: impl IntoIterator<Item = Output>, now: Instant) {
+        for output in expected {
+            self.expect(output, now);
         }
     }
 
-    fn expect_connection_attempts(&mut self, now: &mut Instant, connections: Vec<Output>) {
+    fn expect_idle(&mut self, now: Instant) {
+        assert_eq!(None, self.process_output(now));
+    }
+
+    fn expect_connection_attempts(&mut self, connections: Vec<Output>, now: &mut Instant) {
         for conn in connections {
             *now += CONNECTION_ATTEMPT_DELAY;
-            self.expect(
-                vec![
-                    (None, Some(conn)),
-                    (None, Some(out_connection_attempt_delay())),
-                ],
-                *now,
-            );
+            self.expect(conn, *now);
+            self.expect(out_connection_attempt_delay(), *now);
         }
         *now += CONNECTION_ATTEMPT_DELAY;
-        self.expect(vec![(None, None)], *now);
+        self.expect_idle(*now);
     }
 }
 
@@ -418,10 +430,7 @@ pub fn expect_query(
     hostname: &str,
     rt: DnsRecordType,
 ) {
-    assert_eq!(
-        he.process_output(now),
-        Some(out_send_dns(Id::from(id), hostname, rt))
-    );
+    he.expect(out_send_dns(Id::from(id), hostname, rt), now);
 }
 
 /// Assert the standard opening burst of DNS queries: HTTPS, AAAA, then A for the
@@ -430,4 +439,32 @@ pub fn expect_initial_dns_queries(he: &mut HappyEyeballs, now: Instant) {
     expect_query(he, now, 0, HOSTNAME, DnsRecordType::Https);
     expect_query(he, now, 1, HOSTNAME, DnsRecordType::Aaaa);
     expect_query(he, now, 2, HOSTNAME, DnsRecordType::A);
+}
+
+/// After an HTTPS record names SVC1 as its target, the resolver emits SVC1's
+/// AAAA+A queries (ids 3-4) and then the resolution-delay timer.
+pub fn expect_svc1_dns_queries(he: &mut HappyEyeballs, now: Instant) {
+    he.expect_all(
+        [
+            out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa),
+            out_send_dns(Id::from(4), SVC1, DnsRecordType::A),
+            out_resolution_delay(),
+        ],
+        now,
+    );
+}
+
+/// Like [`expect_svc1_dns_queries`] but for two targets: SVC1 (ids 3-4) and
+/// SVC2 (ids 5-6), then the resolution-delay timer.
+pub fn expect_svc1_svc2_dns_queries(he: &mut HappyEyeballs, now: Instant) {
+    he.expect_all(
+        [
+            out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa),
+            out_send_dns(Id::from(4), SVC1, DnsRecordType::A),
+            out_send_dns(Id::from(5), SVC2, DnsRecordType::Aaaa),
+            out_send_dns(Id::from(6), SVC2, DnsRecordType::A),
+            out_resolution_delay(),
+        ],
+        now,
+    );
 }

--- a/tests/connection_attempts.rs
+++ b/tests/connection_attempts.rs
@@ -16,23 +16,12 @@ fn ipv6_blackhole() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_positive(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h3(Id::from(3))),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_positive(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h3(Id::from(3)), now);
 
     for _ in 0..42 {
         now += CONNECTION_ATTEMPT_DELAY;
@@ -50,27 +39,16 @@ fn connection_attempt_delay() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_positive_no_alpn(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_positive_no_alpn(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
     now += CONNECTION_ATTEMPT_DELAY;
 
-    he.expect(vec![(None, Some(out_attempt_v4_h1_h2(Id::from(4))))], now);
+    he.expect(out_attempt_v4_h1_h2(Id::from(4)), now);
 }
 
 #[test]
@@ -78,27 +56,16 @@ fn never_try_same_attempt_twice() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_negative(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_a_negative(Id::from(2))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_a_negative(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
 
     now += CONNECTION_ATTEMPT_DELAY;
 
-    he.expect(vec![(None, None)], now);
+    he.expect_idle(now);
 }
 
 #[test]
@@ -106,54 +73,41 @@ fn successful_connection_cancels_others() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
+    he.input(in_dns_https_positive_no_alpn(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(1),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR, V6_ADDR_2])),
+        },
+        now,
+    );
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
+
+    now += CONNECTION_ATTEMPT_DELAY;
     he.expect(
-        vec![
-            (
-                Some(in_dns_https_positive_no_alpn(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(1),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR, V6_ADDR_2])),
-                }),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
+        Output::AttemptConnection {
+            id: Id::from(4),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR_2.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H2OrH1,
+                ech_config: None,
+            },
+            is_ech_retry: false,
+        },
         now,
     );
 
     now += CONNECTION_ATTEMPT_DELAY;
-    he.expect(
-        vec![(
-            None,
-            Some(Output::AttemptConnection {
-                id: Id::from(4),
-                endpoint: Endpoint {
-                    address: SocketAddr::new(V6_ADDR_2.into(), PORT),
-                    http_version: ConnectionAttemptHttpVersions::H2OrH1,
-                    ech_config: None,
-                },
-                is_ech_retry: false,
-            }),
-        )],
-        now,
-    );
-
-    now += CONNECTION_ATTEMPT_DELAY;
-    he.expect(vec![(None, Some(out_attempt_v4_h1_h2(Id::from(5))))], now);
-    he.expect(
-        vec![
-            (
-                Some(in_connection_result_positive(Id::from(3))),
-                Some(Output::CancelConnection { id: Id::from(4) }),
-            ),
-            (None, Some(Output::CancelConnection { id: Id::from(5) })),
-            (None, Some(Output::Succeeded)),
+    he.expect(out_attempt_v4_h1_h2(Id::from(5)), now);
+    he.input(in_connection_result_positive(Id::from(3)), now);
+    he.expect_all(
+        [
+            Output::CancelConnection { id: Id::from(4) },
+            Output::CancelConnection { id: Id::from(5) },
+            Output::Succeeded,
         ],
         now,
     );
@@ -164,31 +118,15 @@ fn failed_connection_tries_next_immediately() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_positive_no_alpn(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_positive_no_alpn(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
-    he.expect(
-        vec![(
-            Some(in_connection_result_negative(Id::from(3))),
-            Some(out_attempt_v4_h1_h2(Id::from(4))),
-        )],
-        now,
-    );
+    he.input(in_connection_result_negative(Id::from(3)), now);
+    he.expect(out_attempt_v4_h1_h2(Id::from(4)), now);
 }
 
 #[test]
@@ -196,23 +134,12 @@ fn successful_connection_emits_succeeded() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_positive_no_alpn(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-            (
-                Some(in_connection_result_positive(Id::from(3))),
-                Some(Output::Succeeded),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_positive_no_alpn(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.input(in_connection_result_positive(Id::from(3)), now);
+    he.expect(Output::Succeeded, now);
 }
 
 #[test]
@@ -220,26 +147,15 @@ fn succeeded_keeps_emitting_succeeded() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_positive_no_alpn(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-            (
-                Some(in_connection_result_positive(Id::from(3))),
-                Some(Output::Succeeded),
-            ),
-            // After succeeded, continue to emit Succeeded
-            (None, Some(Output::Succeeded)),
-            (None, Some(Output::Succeeded)),
-        ],
-        now,
-    );
+    he.input(in_dns_https_positive_no_alpn(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.input(in_connection_result_positive(Id::from(3)), now);
+    he.expect(Output::Succeeded, now);
+    // After succeeded, continue to emit Succeeded
+    he.expect(Output::Succeeded, now);
+    he.expect(Output::Succeeded, now);
 }
 
 /// The connection-attempt-delay timer reflects the time *remaining*, not the full delay.
@@ -254,28 +170,16 @@ fn connection_attempt_delay_partial_elapsed() {
 
     // Drive to first connection attempt at time T=now.
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_negative(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
 
     let elapsed = Duration::from_millis(40);
     he.expect(
-        vec![(
-            None,
-            Some(Output::Timer {
-                duration: custom_delay - elapsed,
-            }),
-        )],
+        Output::Timer {
+            duration: custom_delay - elapsed,
+        },
         now + elapsed,
     );
 }
@@ -285,48 +189,25 @@ fn cancelled_connection_result_ignored() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_positive_no_alpn(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_positive_no_alpn(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
     now += CONNECTION_ATTEMPT_DELAY;
 
     // Start second connection attempt.
-    he.expect(vec![(None, Some(out_attempt_v4_h1_h2(Id::from(4))))], now);
+    he.expect(out_attempt_v4_h1_h2(Id::from(4)), now);
 
     // First connection succeeds, triggering cancellation of the second.
-    he.expect(
-        vec![
-            (
-                Some(in_connection_result_positive(Id::from(3))),
-                Some(Output::CancelConnection { id: Id::from(4) }),
-            ),
-            (None, Some(Output::Succeeded)),
-        ],
-        now,
-    );
+    he.input(in_connection_result_positive(Id::from(3)), now);
+    he.expect(Output::CancelConnection { id: Id::from(4) }, now);
+    he.expect(Output::Succeeded, now);
 
     // User reports an error for the already-cancelled connection.
     // This must not panic.
-    he.expect(
-        vec![(
-            Some(in_connection_result_negative(Id::from(4))),
-            Some(Output::Succeeded),
-        )],
-        now,
-    );
+    he.input(in_connection_result_negative(Id::from(4)), now);
+    he.expect(Output::Succeeded, now);
 }

--- a/tests/failure.rs
+++ b/tests/failure.rs
@@ -13,23 +13,12 @@ fn all_dns_failed() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_negative(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_negative(Id::from(1))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_a_negative(Id::from(2))),
-                Some(Output::Failed(FailureReason::DnsResolution)),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_negative(Id::from(1)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_a_negative(Id::from(2)), now);
+    he.expect(Output::Failed(FailureReason::DnsResolution), now);
 }
 
 /// DNS partially fails (HTTPS and A fail) but AAAA succeeds, then connection fails.
@@ -38,27 +27,14 @@ fn dns_partial_failure_then_connection_failed() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_negative(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-            (
-                Some(in_dns_a_negative(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_connection_result_negative(Id::from(3))),
-                Some(Output::Failed(FailureReason::Connection)),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.input(in_dns_a_negative(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_connection_result_negative(Id::from(3)), now);
+    he.expect(Output::Failed(FailureReason::Connection), now);
 }
 
 /// All DNS succeeds but all connection attempts fail.
@@ -67,31 +43,16 @@ fn all_connections_failed() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_positive_no_alpn(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_connection_result_negative(Id::from(3))),
-                Some(out_attempt_v4_h1_h2(Id::from(4))),
-            ),
-            (
-                Some(in_connection_result_negative(Id::from(4))),
-                Some(Output::Failed(FailureReason::Connection)),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_positive_no_alpn(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_connection_result_negative(Id::from(3)), now);
+    he.expect(out_attempt_v4_h1_h2(Id::from(4)), now);
+    he.input(in_connection_result_negative(Id::from(4)), now);
+    he.expect(Output::Failed(FailureReason::Connection), now);
 }
 
 /// When the target is an IP address and the connection fails, the state
@@ -103,26 +64,19 @@ fn ip_host_connection_failure() {
     let mut he = HappyEyeballs::new("127.0.0.1", PORT).unwrap();
 
     he.expect(
-        vec![
-            (
-                None,
-                Some(Output::AttemptConnection {
-                    id: Id::from(0),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H2OrH1,
-                        ech_config: None,
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-            (
-                Some(in_connection_result_negative(Id::from(0))),
-                Some(Output::Failed(FailureReason::Connection)),
-            ),
-        ],
+        Output::AttemptConnection {
+            id: Id::from(0),
+            endpoint: Endpoint {
+                address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), PORT),
+                http_version: ConnectionAttemptHttpVersions::H2OrH1,
+                ech_config: None,
+            },
+            is_ech_retry: false,
+        },
         now,
     );
+    he.input(in_connection_result_negative(Id::from(0)), now);
+    he.expect(Output::Failed(FailureReason::Connection), now);
 }
 
 /// First connection fails, second succeeds. Should not emit `Failed`.
@@ -131,29 +85,14 @@ fn first_connection_fails_second_succeeds() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_positive_no_alpn(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_connection_result_negative(Id::from(3))),
-                Some(out_attempt_v4_h1_h2(Id::from(4))),
-            ),
-            (
-                Some(in_connection_result_positive(Id::from(4))),
-                Some(Output::Succeeded),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_positive_no_alpn(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_connection_result_negative(Id::from(3)), now);
+    he.expect(out_attempt_v4_h1_h2(Id::from(4)), now);
+    he.input(in_connection_result_positive(Id::from(4)), now);
+    he.expect(Output::Succeeded, now);
 }

--- a/tests/hostname_resolution.rs
+++ b/tests/hostname_resolution.rs
@@ -22,19 +22,17 @@ fn expect_hints_move_on_with_timeout(
     expected_attempt: Output,
 ) {
     expect_initial_dns_queries(he, *now);
-    he.expect(
-        vec![(Some(https_input), Some(out_resolution_delay()))],
-        *now,
-    );
+    he.input(https_input, *now);
+    he.expect(out_resolution_delay(), *now);
     *now += RESOLUTION_DELAY;
-    he.expect(vec![(None, Some(expected_attempt))], *now);
+    he.expect(expected_attempt, *now);
 }
 
 #[test]
 fn initial_state() {
     let (now, mut he) = setup();
 
-    he.expect(vec![(None, Some(out_send_dns_https(Id::from(0))))], now);
+    he.expect(out_send_dns_https(Id::from(0)), now);
 }
 
 /// > All of the DNS queries SHOULD be made as soon after one another as
@@ -63,19 +61,10 @@ fn dont_wait_for_all_dns_answers() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_positive(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h3(Id::from(3))),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_positive(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h3(Id::from(3)), now);
 }
 
 /// > The client moves onto sorting addresses and establishing
@@ -176,17 +165,17 @@ fn move_on_non_timeout() {
             let (now, mut he) = setup_with_config(test_case.address_family.clone());
 
             expect_initial_dns_queries(&mut he, now);
-            he.expect(
-                vec![
-                    (
-                        Some(test_case.positive.clone()),
-                        Some(out_resolution_delay()),
-                    ),
-                    (test_case.preferred.clone(), Some(out_resolution_delay())),
-                    (Some(https), test_case.expected.clone()),
-                ],
-                now,
-            );
+            he.input(test_case.positive.clone(), now);
+            he.expect(out_resolution_delay(), now);
+            if let Some(preferred) = test_case.preferred.clone() {
+                he.input(preferred, now);
+            }
+            he.expect(out_resolution_delay(), now);
+            he.input(https, now);
+            match test_case.expected.clone() {
+                Some(expected) => he.expect(expected, now),
+                None => he.expect_idle(now),
+            }
         }
     }
 }
@@ -203,17 +192,12 @@ fn move_on_timeout() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![(
-            Some(in_dns_a_positive(Id::from(2))),
-            Some(out_resolution_delay()),
-        )],
-        now,
-    );
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
 
     now += RESOLUTION_DELAY;
 
-    he.expect(vec![(None, Some(out_attempt_v4_h1_h2(Id::from(3))))], now);
+    he.expect(out_attempt_v4_h1_h2(Id::from(3)), now);
 }
 
 /// > Resolution Delay (Section 4): The time to wait for a AAAA record after
@@ -225,21 +209,14 @@ fn resolution_delay_starts_after_other_response() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            // No other response received yet.
-            (None, None),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_resolution_delay()),
-            ),
-        ],
-        now,
-    );
+    // No other response received yet.
+    he.expect_idle(now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
 
     now += RESOLUTION_DELAY;
 
-    he.expect(vec![(None, Some(out_attempt_v4_h1_h2(Id::from(3))))], now);
+    he.expect(out_attempt_v4_h1_h2(Id::from(3)), now);
 }
 
 /// Start of the Resolution Delay is not the first DNS query is sent, but
@@ -254,36 +231,23 @@ fn resolution_delay_starts_on_first_response() {
     let (start, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, start);
-    he.expect(
-        vec![
-            // No other response received yet.
-            (None, None),
-        ],
-        start,
-    );
+    // No other response received yet.
+    he.expect_idle(start);
 
     // Receive first response, thus activating the resolution delay.
-    he.expect(
-        vec![(
-            Some(in_dns_a_positive(Id::from(2))),
-            Some(out_resolution_delay()),
-        )],
-        start + RESPONSE_DELAY,
-    );
+    he.input(in_dns_a_positive(Id::from(2)), start + RESPONSE_DELAY);
+    he.expect(out_resolution_delay(), start + RESPONSE_DELAY);
 
     // Resolution delay is off of the response, not the query start (i.e. `start`).
     he.expect(
-        vec![(
-            None,
-            Some(Output::Timer {
-                duration: RESPONSE_DELAY,
-            }),
-        )],
+        Output::Timer {
+            duration: RESPONSE_DELAY,
+        },
         start + RESOLUTION_DELAY,
     );
 
     he.expect(
-        vec![(None, Some(out_attempt_v4_h1_h2(Id::from(3))))],
+        out_attempt_v4_h1_h2(Id::from(3)),
         start + RESPONSE_DELAY + RESOLUTION_DELAY,
     );
 }
@@ -307,39 +271,23 @@ fn https_hints() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![(
-            Some(in_dns_https_positive_v4_and_v6_hints(Id::from(0))),
-            Some(out_resolution_delay()),
-        )],
-        now,
-    );
+    he.input(in_dns_https_positive_v4_and_v6_hints(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
 
     now += RESOLUTION_DELAY;
-    he.expect(
-        vec![
-            (None, Some(out_attempt_v6_h3(Id::from(3)))),
-            (None, Some(out_connection_attempt_delay())),
-            // AAAA and A arrive negative: both hints are discarded. The
-            // connection attempt delay is re-emitted while the in-flight
-            // v6 attempt is still pending.
-            (
-                Some(in_dns_aaaa_negative(Id::from(1))),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_dns_a_negative(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-            // The v6 attempt fails. No v4 retry — v4 hint was discarded when
-            // A returned a negative answer.
-            (
-                Some(in_connection_result_negative(Id::from(3))),
-                Some(Output::Failed(FailureReason::Connection)),
-            ),
-        ],
-        now,
-    );
+    he.expect(out_attempt_v6_h3(Id::from(3)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    // AAAA and A arrive negative: both hints are discarded. The
+    // connection attempt delay is re-emitted while the in-flight
+    // v6 attempt is still pending.
+    he.input(in_dns_aaaa_negative(Id::from(1)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_dns_a_negative(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    // The v6 attempt fails. No v4 retry — v4 hint was discarded when
+    // A returned a negative answer.
+    he.input(in_connection_result_negative(Id::from(3)), now);
+    he.expect(Output::Failed(FailureReason::Connection), now);
 }
 
 /// HTTPS IP hints should count as positive address answers for the
@@ -381,32 +329,21 @@ fn resolution_delay_boundary() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            // HTTPS negative and A positive arrive at T; AAAA still pending.
-            (
-                Some(in_dns_https_negative(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_resolution_delay()),
-            ),
-        ],
-        now,
-    );
+    // HTTPS negative and A positive arrive at T; AAAA still pending.
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
 
     now += RESOLUTION_DELAY;
 
     // Resolution delay has elapsed; move_on_with_timeout fires.
-    he.expect(vec![(None, Some(out_attempt_v4_h1_h2(Id::from(3))))], now);
+    he.expect(out_attempt_v4_h1_h2(Id::from(3)), now);
 
     // Connection fails immediately. AAAA still pending, resolution delay exactly
     // expired — no timer, just None.
-    he.expect(
-        vec![(Some(in_connection_result_negative(Id::from(3))), None)],
-        now,
-    );
+    he.input(in_connection_result_negative(Id::from(3)), now);
+    he.expect_idle(now);
 }
 
 /// > Note that clients are still required to issue A and AAAA queries
@@ -418,13 +355,8 @@ fn https_hints_still_query_a_aaaa() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![(
-            Some(in_dns_https_positive_svc1(Id::from(0))),
-            Some(out_send_dns_svc1(Id::from(3))),
-        )],
-        now,
-    );
+    he.input(in_dns_https_positive_svc1(Id::from(0)), now);
+    he.expect(out_send_dns_svc1(Id::from(3)), now);
 }
 
 #[test]
@@ -432,19 +364,10 @@ fn https_h3_upgrade_without_hints() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_https_positive(Id::from(0))),
-                Some(out_attempt_v6_h3(Id::from(3))),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_https_positive(Id::from(0)), now);
+    he.expect(out_attempt_v6_h3(Id::from(3)), now);
 }
 
 /// A ServiceInfo advertising H3 must not produce an H3 connection attempt
@@ -461,19 +384,10 @@ fn https_h3_disabled() {
     });
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_https_positive(Id::from(0))),
-                Some(out_attempt_v6_h2(Id::from(3))),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_https_positive(Id::from(0)), now);
+    he.expect(out_attempt_v6_h2(Id::from(3)), now);
 }
 
 #[test]
@@ -481,42 +395,31 @@ fn multiple_ips_per_record() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_negative(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_a_negative(Id::from(2))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(1),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR, V6_ADDR_2, V6_ADDR_3])),
-                }),
-                Some(out_attempt_v6_h1_h2(Id::from(3))),
-            ),
-        ],
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_a_negative(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(1),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR, V6_ADDR_2, V6_ADDR_3])),
+        },
         now,
     );
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
 
     now += CONNECTION_ATTEMPT_DELAY;
 
     he.expect(
-        vec![(
-            None,
-            Some(Output::AttemptConnection {
-                id: Id::from(4),
-                endpoint: Endpoint {
-                    address: SocketAddr::new(V6_ADDR_2.into(), PORT),
-                    http_version: ConnectionAttemptHttpVersions::H2OrH1,
-                    ech_config: None,
-                },
-                is_ech_retry: false,
-            }),
-        )],
+        Output::AttemptConnection {
+            id: Id::from(4),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR_2.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H2OrH1,
+                ech_config: None,
+            },
+            is_ech_retry: false,
+        },
         now,
     );
 }
@@ -553,19 +456,13 @@ fn single_stack_skips_disabled_address_family() {
             ..NetworkConfig::default()
         });
 
-        he.expect(
-            vec![
-                (None, Some(out_send_dns_https(Id::from(0)))),
-                // Should skip the disabled address family query.
-                (None, Some(case.expected_dns_query)),
-                (
-                    Some(in_dns_https_negative(Id::from(0))),
-                    Some(out_resolution_delay()),
-                ),
-                (Some(case.dns_response), Some(case.expected_connection)),
-            ],
-            now,
-        );
+        he.expect(out_send_dns_https(Id::from(0)), now);
+        // Should skip the disabled address family query.
+        he.expect(case.expected_dns_query, now);
+        he.input(in_dns_https_negative(Id::from(0)), now);
+        he.expect(out_resolution_delay(), now);
+        he.input(case.dns_response, now);
+        he.expect(case.expected_connection, now);
     }
 }
 
@@ -602,19 +499,12 @@ fn single_stack_target_name_skips_disabled_address_family() {
             ..NetworkConfig::default()
         });
 
-        he.expect(
-            vec![
-                (None, Some(out_send_dns_https(Id::from(0)))),
-                (None, Some(case.origin_dns_query)),
-                (
-                    Some(in_dns_https_positive_svc1(Id::from(0))),
-                    Some(case.target_name_dns_query),
-                ),
-                // No query for the disabled address family should appear,
-                // only the resolution delay.
-                (None, Some(out_resolution_delay())),
-            ],
-            now,
-        );
+        he.expect(out_send_dns_https(Id::from(0)), now);
+        he.expect(case.origin_dns_query, now);
+        he.input(in_dns_https_positive_svc1(Id::from(0)), now);
+        he.expect(case.target_name_dns_query, now);
+        // No query for the disabled address family should appear,
+        // only the resolution delay.
+        he.expect(out_resolution_delay(), now);
     }
 }

--- a/tests/https_records.rs
+++ b/tests/https_records.rs
@@ -19,35 +19,30 @@ fn ech_config_propagated_to_endpoint() {
     // still in-flight. After the resolution delay the hint is used, and the
     // ECH config must be carried onto the endpoint.
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![(
-            Some(Input::DnsResult {
-                id: Id::from(0),
-                result: DnsResult::Https(Ok(vec![
-                    service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
-                        .ipv6_hints(vec![V6_ADDR])
-                        .ech(),
-                ])),
-            }),
-            Some(out_resolution_delay()),
-        )],
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
+                    .ipv6_hints(vec![V6_ADDR])
+                    .ech(),
+            ])),
+        },
         now,
     );
+    he.expect(out_resolution_delay(), now);
 
     now += RESOLUTION_DELAY;
     he.expect(
-        vec![(
-            None,
-            Some(Output::AttemptConnection {
-                id: Id::from(3),
-                endpoint: Endpoint {
-                    address: SocketAddr::new(V6_ADDR.into(), PORT),
-                    http_version: ConnectionAttemptHttpVersions::H3,
-                    ech_config: Some(ech_config()),
-                },
-                is_ech_retry: false,
-            }),
-        )],
+        Output::AttemptConnection {
+            id: Id::from(3),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H3,
+                ech_config: Some(ech_config()),
+            },
+            is_ech_retry: false,
+        },
         now,
     );
 }
@@ -106,26 +101,24 @@ fn hints_discarded_on_negative_answer() {
         let (mut now, mut he) = setup_with_config(case.config);
 
         expect_initial_dns_queries(&mut he, now);
-        he.expect(
-            vec![
-                (Some(case.first_arrives), Some(out_resolution_delay())),
-                (Some(case.second_arrives), Some(out_resolution_delay())),
-                (
-                    Some(Input::DnsResult {
-                        id: Id::from(0),
-                        result: DnsResult::Https(Ok(vec![
-                            service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
-                                .ipv6_hints(case.ipv6_hints)
-                                .ipv4_hints(case.ipv4_hints),
-                        ])),
-                    }),
-                    Some(case.attempt_1),
-                ),
-            ],
+        he.input(case.first_arrives, now);
+        he.expect(out_resolution_delay(), now);
+        he.input(case.second_arrives, now);
+        he.expect(out_resolution_delay(), now);
+        he.input(
+            Input::DnsResult {
+                id: Id::from(0),
+                result: DnsResult::Https(Ok(vec![
+                    service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
+                        .ipv6_hints(case.ipv6_hints)
+                        .ipv4_hints(case.ipv4_hints),
+                ])),
+            },
             now,
         );
+        he.expect(case.attempt_1, now);
 
-        he.expect_connection_attempts(&mut now, vec![case.attempt_2, case.attempt_3]);
+        he.expect_connection_attempts(vec![case.attempt_2, case.attempt_3], &mut now);
     }
 }
 
@@ -147,44 +140,38 @@ fn ech_disabled() {
     });
 
     expect_initial_dns_queries(&mut he, now);
+    he.input(in_dns_a_negative(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            // Only H3 in ALPN — fallback bucket uses H2OrH1 by default.
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H3])
+                    .ipv6_hints(vec![V6_ADDR])
+                    .ech(),
+            ])),
+        },
+        now,
+    );
+    // HTTPS bucket: V6:H3, but ECH stripped.
     he.expect(
-        vec![
-            (
-                Some(in_dns_a_negative(Id::from(2))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    // Only H3 in ALPN — fallback bucket uses H2OrH1 by default.
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H3])
-                            .ipv6_hints(vec![V6_ADDR])
-                            .ech(),
-                    ])),
-                }),
-                // HTTPS bucket: V6:H3, but ECH stripped.
-                Some(Output::AttemptConnection {
-                    id: Id::from(3),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H3,
-                        ech_config: None,
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-        ],
+        Output::AttemptConnection {
+            id: Id::from(3),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H3,
+                ech_config: None,
+            },
+            is_ech_retry: false,
+        },
         now,
     );
 
     // Origin fallback is NOT skipped despite HTTPS record having ECH.
     he.expect_connection_attempts(
-        &mut now,
         vec![Output::AttemptConnection {
             id: Id::from(4),
             endpoint: Endpoint {
@@ -194,6 +181,7 @@ fn ech_disabled() {
             },
             is_ech_retry: false,
         }],
+        &mut now,
     );
 }
 
@@ -202,30 +190,27 @@ fn ech_config_from_https_applies_to_aaaa() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).ech(),
+            ])),
+        },
+        now,
+    );
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
     he.expect(
-        vec![
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).ech(),
-                    ])),
-                }),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(Output::AttemptConnection {
-                    id: Id::from(3),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H3,
-                        ech_config: Some(ech_config()),
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-        ],
+        Output::AttemptConnection {
+            id: Id::from(3),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H3,
+                ech_config: Some(ech_config()),
+            },
+            is_ech_retry: false,
+        },
         now,
     );
 }
@@ -235,28 +220,22 @@ fn multiple_target_names() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
+    // HTTPS response with a different target name
+    he.input(in_dns_https_positive_svc1(Id::from(0)), now);
+    he.expect(out_send_dns_svc1(Id::from(3)), now);
+    // Now we have queries for both "example.com" and "svc1.example.com."
+    // Getting a positive AAAA for the main host
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
     he.expect(
-        vec![
-            // HTTPS response with a different target name
-            (
-                Some(in_dns_https_positive_svc1(Id::from(0))),
-                Some(out_send_dns_svc1(Id::from(3))),
-            ),
-            // Now we have queries for both "example.com" and "svc1.example.com."
-            // Getting a positive AAAA for the main host
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(Output::AttemptConnection {
-                    id: Id::from(4),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR_2.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H3,
-                        ech_config: None,
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-        ],
+        Output::AttemptConnection {
+            id: Id::from(4),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR_2.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H3,
+                ech_config: None,
+            },
+            is_ech_retry: false,
+        },
         now,
     );
 }
@@ -286,65 +265,54 @@ fn partial_ech_two_service_infos() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, SVC1, &[HttpVersion::H3])
+                    .ech()
+                    .port(SVC1_PORT),
+                service_info(2, SVC2, &[HttpVersion::H2]).port(SVC2_PORT),
+            ])),
+        },
+        now,
+    );
+    // Only SVC1 gets DNS queries — SVC2 is skipped (no ECH)
+    expect_svc1_dns_queries(&mut he, now);
+    // HOSTNAME AAAA positive -> move-on criteria met, but SVC1 has no
+    // addresses yet and ECH filtering skips fallback -> no attempt yet.
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
+    // SVC1 AAAA negative
+    he.input(in_dns_aaaa_negative(Id::from(3)), now);
+    he.expect(out_resolution_delay(), now);
+    // SVC1 A positive -> SVC1 bucket now has addresses, first attempt
+    he.input(
+        Input::DnsResult {
+            id: Id::from(4),
+            result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+        },
+        now,
+    );
     he.expect(
-        vec![
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, SVC1, &[HttpVersion::H3])
-                            .ech()
-                            .port(SVC1_PORT),
-                        service_info(2, SVC2, &[HttpVersion::H2]).port(SVC2_PORT),
-                    ])),
-                }),
-                // Only SVC1 gets DNS queries — SVC2 is skipped (no ECH)
-                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
-            ),
-            (None, Some(out_resolution_delay())),
-            // HOSTNAME AAAA positive -> move-on criteria met, but SVC1 has no
-            // addresses yet and ECH filtering skips fallback -> no attempt yet.
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_resolution_delay()),
-            ),
-            // SVC1 AAAA negative
-            (
-                Some(in_dns_aaaa_negative(Id::from(3))),
-                Some(out_resolution_delay()),
-            ),
-            // SVC1 A positive -> SVC1 bucket now has addresses, first attempt
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(4),
-                    result: DnsResult::A(Ok(vec![V4_ADDR_2])),
-                }),
-                Some(Output::AttemptConnection {
-                    id: Id::from(5),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V4_ADDR_2.into(), SVC1_PORT),
-                        http_version: ConnectionAttemptHttpVersions::H3,
-                        ech_config: Some(ech_config()),
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-        ],
+        Output::AttemptConnection {
+            id: Id::from(5),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V4_ADDR_2.into(), SVC1_PORT),
+                http_version: ConnectionAttemptHttpVersions::H3,
+                ech_config: Some(ech_config()),
+            },
+            is_ech_retry: false,
+        },
         now,
     );
 
     // SVC1 advertises only alpn=h3, so it produces a single H3 attempt; there
     // is no H2 attempt because H2 belongs to SVC2's record.
     now += CONNECTION_ATTEMPT_DELAY;
-    he.expect(vec![(None, None)], now);
+    he.expect_idle(now);
 }
 
 /// Both ServiceInfo records have ECH. The origin fallback is still skipped
@@ -369,89 +337,68 @@ fn both_service_infos_have_ech_no_origin_fallback() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, SVC1, &[HttpVersion::H3])
-                            .ech()
-                            .port(SVC1_PORT),
-                        service_info(2, SVC2, &[HttpVersion::H2])
-                            .ech()
-                            .port(SVC2_PORT),
-                    ])),
-                }),
-                // Both SVC1 and SVC2 get DNS queries (both have ECH)
-                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(5), SVC2, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(6), SVC2, DnsRecordType::A)),
-            ),
-            (None, Some(out_resolution_delay())),
-            // HOSTNAME AAAA/A positive — but fallback will be skipped (no ECH)
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_resolution_delay()),
-            ),
-            // SVC1 AAAA negative
-            (
-                Some(in_dns_aaaa_negative(Id::from(3))),
-                Some(out_resolution_delay()),
-            ),
-            // SVC1 A positive -> first attempt from SVC1 bucket
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(4),
-                    result: DnsResult::A(Ok(vec![V4_ADDR_2])),
-                }),
-                Some(Output::AttemptConnection {
-                    id: Id::from(7),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V4_ADDR_2.into(), SVC1_PORT),
-                        http_version: ConnectionAttemptHttpVersions::H3,
-                        ech_config: Some(ech_config()),
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-            (None, Some(out_connection_attempt_delay())),
-            // SVC2 AAAA negative
-            (
-                Some(in_dns_aaaa_negative(Id::from(5))),
-                Some(out_connection_attempt_delay()),
-            ),
-            // SVC2 A positive
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(6),
-                    result: DnsResult::A(Ok(vec![V4_ADDR])),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, SVC1, &[HttpVersion::H3])
+                    .ech()
+                    .port(SVC1_PORT),
+                service_info(2, SVC2, &[HttpVersion::H2])
+                    .ech()
+                    .port(SVC2_PORT),
+            ])),
+        },
         now,
     );
+    // Both SVC1 and SVC2 get DNS queries (both have ECH)
+    expect_svc1_svc2_dns_queries(&mut he, now);
+    // HOSTNAME AAAA/A positive — but fallback will be skipped (no ECH)
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
+    // SVC1 AAAA negative
+    he.input(in_dns_aaaa_negative(Id::from(3)), now);
+    he.expect(out_resolution_delay(), now);
+    // SVC1 A positive -> first attempt from SVC1 bucket
+    he.input(
+        Input::DnsResult {
+            id: Id::from(4),
+            result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+        },
+        now,
+    );
+    he.expect(
+        Output::AttemptConnection {
+            id: Id::from(7),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V4_ADDR_2.into(), SVC1_PORT),
+                http_version: ConnectionAttemptHttpVersions::H3,
+                ech_config: Some(ech_config()),
+            },
+            is_ech_retry: false,
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    // SVC2 AAAA negative
+    he.input(in_dns_aaaa_negative(Id::from(5)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    // SVC2 A positive
+    he.input(
+        Input::DnsResult {
+            id: Id::from(6),
+            result: DnsResult::A(Ok(vec![V4_ADDR])),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
 
     // Both SVC1 and SVC2 produce attempts (both have ECH), each using only its
     // own record's ALPN: SVC1 is H3-only, SVC2 is H2-only. Origin fallback is
     // skipped — no ECH on the origin.
     he.expect_connection_attempts(
-        &mut now,
         vec![
             // priority=2 (SVC2, port 10443, ech, alpn=h2)
             Output::AttemptConnection {
@@ -464,6 +411,7 @@ fn both_service_infos_have_ech_no_origin_fallback() {
                 is_ech_retry: false,
             },
         ],
+        &mut now,
     );
 }
 
@@ -490,79 +438,64 @@ fn per_record_alpn_not_unioned_across_records() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, SVC1, &[HttpVersion::H3]),
-                        service_info(2, SVC2, &[HttpVersion::H2]),
-                    ])),
-                }),
-                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(5), SVC2, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(6), SVC2, DnsRecordType::A)),
-            ),
-            (None, Some(out_resolution_delay())),
-            // svc1 (alpn=h3) AAAA arrives -> first attempt is H3-only.
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(3),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
-                }),
-                Some(out_attempt(
-                    Id::from(7),
-                    V6_ADDR_2.into(),
-                    PORT,
-                    ConnectionAttemptHttpVersions::H3,
-                )),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(4),
-                    result: DnsResult::A(Err(())),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(5),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR_3])),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(6),
-                    result: DnsResult::A(Err(())),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_dns_a_negative(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, SVC1, &[HttpVersion::H3]),
+                service_info(2, SVC2, &[HttpVersion::H2]),
+            ])),
+        },
         now,
     );
+    expect_svc1_svc2_dns_queries(&mut he, now);
+    // svc1 (alpn=h3) AAAA arrives -> first attempt is H3-only.
+    he.input(
+        Input::DnsResult {
+            id: Id::from(3),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
+        },
+        now,
+    );
+    he.expect(
+        out_attempt(
+            Id::from(7),
+            V6_ADDR_2.into(),
+            PORT,
+            ConnectionAttemptHttpVersions::H3,
+        ),
+        now,
+    );
+    he.input(
+        Input::DnsResult {
+            id: Id::from(4),
+            result: DnsResult::A(Err(())),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(5),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR_3])),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(6),
+            result: DnsResult::A(Err(())),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_dns_a_negative(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
     he.expect_connection_attempts(
-        &mut now,
         vec![
             // svc2 (alpn=h2): H2-only, no spurious H3 from svc1's record.
             out_attempt(
@@ -574,6 +507,7 @@ fn per_record_alpn_not_unioned_across_records() {
             // origin fallback: default H2OrH1.
             out_attempt_v6_h1_h2(Id::from(9)),
         ],
+        &mut now,
     );
 }
 
@@ -601,80 +535,66 @@ fn record_without_alpn_contributes_no_endpoints() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, SVC1, &[HttpVersion::H3]),
-                        service_info(2, SVC2, &[]),
-                    ])),
-                }),
-                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(5), SVC2, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(6), SVC2, DnsRecordType::A)),
-            ),
-            (None, Some(out_resolution_delay())),
-            // svc1 (alpn=h3) AAAA -> first attempt is H3.
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(3),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
-                }),
-                Some(out_attempt(
-                    Id::from(7),
-                    V6_ADDR_2.into(),
-                    PORT,
-                    ConnectionAttemptHttpVersions::H3,
-                )),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(4),
-                    result: DnsResult::A(Err(())),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(5),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR_3])),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(6),
-                    result: DnsResult::A(Err(())),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_dns_a_negative(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, SVC1, &[HttpVersion::H3]),
+                service_info(2, SVC2, &[]),
+            ])),
+        },
         now,
     );
+    expect_svc1_svc2_dns_queries(&mut he, now);
+    // svc1 (alpn=h3) AAAA -> first attempt is H3.
+    he.input(
+        Input::DnsResult {
+            id: Id::from(3),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
+        },
+        now,
+    );
+    he.expect(
+        out_attempt(
+            Id::from(7),
+            V6_ADDR_2.into(),
+            PORT,
+            ConnectionAttemptHttpVersions::H3,
+        ),
+        now,
+    );
+    he.input(
+        Input::DnsResult {
+            id: Id::from(4),
+            result: DnsResult::A(Err(())),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(5),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR_3])),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(6),
+            result: DnsResult::A(Err(())),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_dns_a_negative(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
     // svc2 has no ALPN, so it produces no endpoints (its resolved V6_ADDR_3 is
     // never attempted). Only svc1's H3 attempt and the origin fallback remain.
-    he.expect_connection_attempts(&mut now, vec![out_attempt_v6_h1_h2(Id::from(8))]);
+    he.expect_connection_attempts(vec![out_attempt_v6_h1_h2(Id::from(8))], &mut now);
 }
 
 /// Partial ECH with an alt-svc record on the origin. Both alt-svc and origin
@@ -710,64 +630,53 @@ fn partial_ech_with_alt_svc() {
     let (mut now, mut he) = setup_with_config(config);
 
     expect_initial_dns_queries(&mut he, now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, SVC1, &[HttpVersion::H3])
+                    .ech()
+                    .port(SVC1_PORT),
+                service_info(2, SVC2, &[HttpVersion::H2]).port(SVC2_PORT),
+            ])),
+        },
+        now,
+    );
+    // Only SVC1 gets DNS queries — SVC2 skipped (no ECH)
+    expect_svc1_dns_queries(&mut he, now);
+    // HOSTNAME AAAA/A positive
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
+    // SVC1 AAAA negative
+    he.input(in_dns_aaaa_negative(Id::from(3)), now);
+    he.expect(out_resolution_delay(), now);
+    // SVC1 A positive -> first attempt from SVC1 bucket
+    he.input(
+        Input::DnsResult {
+            id: Id::from(4),
+            result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+        },
+        now,
+    );
     he.expect(
-        vec![
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, SVC1, &[HttpVersion::H3])
-                            .ech()
-                            .port(SVC1_PORT),
-                        service_info(2, SVC2, &[HttpVersion::H2]).port(SVC2_PORT),
-                    ])),
-                }),
-                // Only SVC1 gets DNS queries — SVC2 skipped (no ECH)
-                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
-            ),
-            (None, Some(out_resolution_delay())),
-            // HOSTNAME AAAA/A positive
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_resolution_delay()),
-            ),
-            // SVC1 AAAA negative
-            (
-                Some(in_dns_aaaa_negative(Id::from(3))),
-                Some(out_resolution_delay()),
-            ),
-            // SVC1 A positive -> first attempt from SVC1 bucket
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(4),
-                    result: DnsResult::A(Ok(vec![V4_ADDR_2])),
-                }),
-                Some(Output::AttemptConnection {
-                    id: Id::from(5),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V4_ADDR_2.into(), SVC1_PORT),
-                        http_version: ConnectionAttemptHttpVersions::H3,
-                        ech_config: Some(ech_config()),
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-        ],
+        Output::AttemptConnection {
+            id: Id::from(5),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V4_ADDR_2.into(), SVC1_PORT),
+                http_version: ConnectionAttemptHttpVersions::H3,
+                ech_config: Some(ech_config()),
+            },
+            is_ech_retry: false,
+        },
         now,
     );
 
     // Only SVC1 (with ECH), and it advertises only alpn=h3, so a single H3
     // attempt. Alt-svc, SVC2, and fallback all skipped.
     now += CONNECTION_ATTEMPT_DELAY;
-    he.expect(vec![(None, None)], now);
+    he.expect_idle(now);
 }
 
 mod https_port_svcparam_overrides_port_for {
@@ -780,27 +689,22 @@ mod https_port_svcparam_overrides_port_for {
         // After the resolution delay the hint is used; the connection attempt
         // must use 8443, not the authority port 443. IPv6 is preferred.
         expect_initial_dns_queries(&mut he, now);
-        he.expect(
-            vec![(
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
-                            .ipv6_hints(vec![V6_ADDR])
-                            .ipv4_hints(ipv4_hints)
-                            .port(CUSTOM_PORT),
-                    ])),
-                }),
-                Some(out_resolution_delay()),
-            )],
+        he.input(
+            Input::DnsResult {
+                id: Id::from(0),
+                result: DnsResult::Https(Ok(vec![
+                    service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
+                        .ipv6_hints(vec![V6_ADDR])
+                        .ipv4_hints(ipv4_hints)
+                        .port(CUSTOM_PORT),
+                ])),
+            },
             now,
         );
+        he.expect(out_resolution_delay(), now);
 
         now += RESOLUTION_DELAY;
-        he.expect(
-            vec![(None, Some(out_attempt_v6_h3_custom_port(Id::from(3))))],
-            now,
-        );
+        he.expect(out_attempt_v6_h3_custom_port(Id::from(3)), now);
     }
 
     #[test]
@@ -821,36 +725,25 @@ fn https_port_svcparam_applies_to_resolved_a_and_aaaa() {
     let (now, mut he) = setup(); // constructed with PORT (443)
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            // HTTPS record with port=8443, no hints
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
-                            .port(CUSTOM_PORT),
-                    ])),
-                }),
-                Some(out_resolution_delay()),
-            ),
-            // Positive AAAA: connection attempt must use port 8443, not 443
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h3_custom_port(Id::from(3))),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-            // Positive A: connection attempt must use port 8443, not 443
-            (
-                Some(in_connection_result_negative(Id::from(3))),
-                Some(out_attempt_v4_h3_custom_port(Id::from(4))),
-            ),
-        ],
+    // HTTPS record with port=8443, no hints
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).port(CUSTOM_PORT),
+            ])),
+        },
         now,
     );
+    he.expect(out_resolution_delay(), now);
+    // Positive AAAA: connection attempt must use port 8443, not 443
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h3_custom_port(Id::from(3)), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    // Positive A: connection attempt must use port 8443, not 443
+    he.input(in_connection_result_negative(Id::from(3)), now);
+    he.expect(out_attempt_v4_h3_custom_port(Id::from(4)), now);
 }
 
 #[test]
@@ -858,44 +751,37 @@ fn https_port_svcparam_applies_but_fallbacks_follow() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            // HTTPS record with port=8443, no hints
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
-                            .port(CUSTOM_PORT),
-                    ])),
-                }),
-                Some(out_resolution_delay()),
-            ),
-            // Positive AAAA: connection attempt must use port 8443, not 443
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(Output::AttemptConnection {
-                    id: Id::from(3),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR.into(), CUSTOM_PORT),
-                        http_version: ConnectionAttemptHttpVersions::H3,
-                        ech_config: None,
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
+    // HTTPS record with port=8443, no hints
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).port(CUSTOM_PORT),
+            ])),
+        },
         now,
     );
+    he.expect(out_resolution_delay(), now);
+    // Positive AAAA: connection attempt must use port 8443, not 443
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(
+        Output::AttemptConnection {
+            id: Id::from(3),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR.into(), CUSTOM_PORT),
+                http_version: ConnectionAttemptHttpVersions::H3,
+                ech_config: None,
+            },
+            is_ech_retry: false,
+        },
+        now,
+    );
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
     // Connection attempts using custom port: V4:H3, V6:H2, V4:H2, then
     // fallback on port 443 with default HTTP versions (H2OrH1).
     he.expect_connection_attempts(
-        &mut now,
         vec![
             out_attempt_v4_h3_custom_port(Id::from(4)),
             out_attempt_v6_h2_custom_port(Id::from(5)),
@@ -903,6 +789,7 @@ fn https_port_svcparam_applies_but_fallbacks_follow() {
             out_attempt_v6_h1_h2(Id::from(7)),
             out_attempt_v4_h1_h2(Id::from(8)),
         ],
+        &mut now,
     );
 }
 
@@ -939,40 +826,29 @@ fn https_two_service_infos_with_different_ports() {
         };
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            // Two ServiceInfo records; the lower priority number wins first.
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).port(PORT_1),
-                        service_info(2, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).port(PORT_2),
-                    ])),
-                }),
-                Some(out_resolution_delay()),
-            ),
-            // AAAA arrives; move-on criteria met. First bucket is PORT_1.
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(attempt(
-                    3,
-                    V6_ADDR.into(),
-                    PORT_1,
-                    ConnectionAttemptHttpVersions::H3,
-                )),
-            ),
-            (None, Some(out_connection_attempt_delay())),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
+    // Two ServiceInfo records; the lower priority number wins first.
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).port(PORT_1),
+                service_info(2, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).port(PORT_2),
+            ])),
+        },
         now,
     );
+    he.expect(out_resolution_delay(), now);
+    // AAAA arrives; move-on criteria met. First bucket is PORT_1.
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(
+        attempt(3, V6_ADDR.into(), PORT_1, ConnectionAttemptHttpVersions::H3),
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
     he.expect_connection_attempts(
-        &mut now,
         vec![
             // Priority-1 bucket (port 20007): V4:H3, V6:H2, V4:H2.
             attempt(4, V4_ADDR.into(), PORT_1, ConnectionAttemptHttpVersions::H3),
@@ -992,6 +868,7 @@ fn https_two_service_infos_with_different_ports() {
             out_attempt_v6_h1_h2(Id::from(11)),
             out_attempt_v4_h1_h2(Id::from(12)),
         ],
+        &mut now,
     );
 }
 
@@ -1003,48 +880,25 @@ fn no_default_alpn() {
     let (now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_positive(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h3(Id::from(3))),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_connection_result_negative(Id::from(3))),
-                Some(out_attempt_v4_h3(Id::from(4))),
-            ),
-            (
-                Some(in_connection_result_negative(Id::from(4))),
-                Some(out_attempt_v6_h2(Id::from(5))),
-            ),
-            (
-                Some(in_connection_result_negative(Id::from(5))),
-                Some(out_attempt_v4_h2(Id::from(6))),
-            ),
-            // Fallback bucket with default HTTP versions (H2OrH1).
-            (
-                Some(in_connection_result_negative(Id::from(6))),
-                Some(out_attempt_v6_h1_h2(Id::from(7))),
-            ),
-            (
-                Some(in_connection_result_negative(Id::from(7))),
-                Some(out_attempt_v4_h1_h2(Id::from(8))),
-            ),
-            (
-                Some(in_connection_result_negative(Id::from(8))),
-                Some(Output::Failed(FailureReason::Connection)),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_positive(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h3(Id::from(3)), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_connection_result_negative(Id::from(3)), now);
+    he.expect(out_attempt_v4_h3(Id::from(4)), now);
+    he.input(in_connection_result_negative(Id::from(4)), now);
+    he.expect(out_attempt_v6_h2(Id::from(5)), now);
+    he.input(in_connection_result_negative(Id::from(5)), now);
+    he.expect(out_attempt_v4_h2(Id::from(6)), now);
+    // Fallback bucket with default HTTP versions (H2OrH1).
+    he.input(in_connection_result_negative(Id::from(6)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(7)), now);
+    he.input(in_connection_result_negative(Id::from(7)), now);
+    he.expect(out_attempt_v4_h1_h2(Id::from(8)), now);
+    he.input(in_connection_result_negative(Id::from(8)), now);
+    he.expect(Output::Failed(FailureReason::Connection), now);
 }
 
 #[test]
@@ -1052,48 +906,37 @@ fn https_svc1_addresses_trigger_additional_attempts() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H2, HttpVersion::H3]),
-                        service_info(2, SVC1, &[HttpVersion::H2, HttpVersion::H3]),
-                    ])),
-                }),
-                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
-            ),
-            (None, Some(out_resolution_delay())),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h3(Id::from(5))),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(3),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(4),
-                    result: DnsResult::A(Ok(vec![V4_ADDR_2])),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H2, HttpVersion::H3]),
+                service_info(2, SVC1, &[HttpVersion::H2, HttpVersion::H3]),
+            ])),
+        },
         now,
     );
+    expect_svc1_dns_queries(&mut he, now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h3(Id::from(5)), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(3),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(4),
+            result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
 
     let attempt = |id: u64, addr: IpAddr, http_version: ConnectionAttemptHttpVersions| {
         Output::AttemptConnection {
@@ -1111,7 +954,6 @@ fn https_svc1_addresses_trigger_additional_attempts() {
     // come before P2 (SVC1, priority=2) endpoints.  V6_ADDR:H3 was already
     // attempted (id=5); the remaining follow in priority order, then fallback.
     he.expect_connection_attempts(
-        &mut now,
         vec![
             attempt(6, V4_ADDR.into(), ConnectionAttemptHttpVersions::H3), // priority=1
             attempt(7, V6_ADDR.into(), ConnectionAttemptHttpVersions::H2), // priority=1
@@ -1124,6 +966,7 @@ fn https_svc1_addresses_trigger_additional_attempts() {
             attempt(13, V6_ADDR.into(), ConnectionAttemptHttpVersions::H2OrH1),
             attempt(14, V4_ADDR.into(), ConnectionAttemptHttpVersions::H2OrH1),
         ],
+        &mut now,
     );
 }
 
@@ -1150,39 +993,32 @@ fn https_port_takes_precedence_over_alt_svc_port() {
     let (mut now, mut he) = setup_with_config(config);
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            // HTTPS record with port=8443
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2])
-                            .port(HTTPS_PORT),
-                    ])),
-                }),
-                Some(out_resolution_delay()),
-            ),
-            // AAAA arrives; HTTPS bucket first (port 8443)
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt(
-                    Id::from(3),
-                    V6_ADDR.into(),
-                    HTTPS_PORT,
-                    ConnectionAttemptHttpVersions::H3,
-                )),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
+    // HTTPS record with port=8443
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H3, HttpVersion::H2]).port(HTTPS_PORT),
+            ])),
+        },
         now,
     );
+    he.expect(out_resolution_delay(), now);
+    // AAAA arrives; HTTPS bucket first (port 8443)
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(
+        out_attempt(
+            Id::from(3),
+            V6_ADDR.into(),
+            HTTPS_PORT,
+            ConnectionAttemptHttpVersions::H3,
+        ),
+        now,
+    );
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
     he.expect_connection_attempts(
-        &mut now,
         vec![
             // HTTPS bucket (port 8443)
             out_attempt(
@@ -1230,6 +1066,7 @@ fn https_port_takes_precedence_over_alt_svc_port() {
                 ConnectionAttemptHttpVersions::H2OrH1,
             ),
         ],
+        &mut now,
     );
 }
 
@@ -1255,64 +1092,55 @@ fn target_name_redirect_addresses_used_in_connection_attempts() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            // HTTPS response redirects to SVC1 (different target name, no hints)
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![service_info(1, SVC1, &[HttpVersion::H3])])),
-                }),
-                // Follow-up DNS for the redirected target name
-                Some(out_send_dns(Id::from(3), SVC1, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(4), SVC1, DnsRecordType::A)),
-            ),
-            (None, Some(out_resolution_delay())),
-            // SVC1 AAAA positive → move-on criteria met, first attempt uses
-            // the redirected target name's resolved address.
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(3),
-                    result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
-                }),
-                Some(Output::AttemptConnection {
-                    id: Id::from(5),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR_2.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H3,
-                        ech_config: None,
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-            (None, Some(out_connection_attempt_delay())),
-            // Remaining DNS arrives while first attempt is in progress
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(4),
-                    result: DnsResult::A(Ok(vec![V4_ADDR_2])),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
+    // HTTPS response redirects to SVC1 (different target name, no hints)
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![service_info(1, SVC1, &[HttpVersion::H3])])),
+        },
         now,
     );
+    // Follow-up DNS for the redirected target name
+    expect_svc1_dns_queries(&mut he, now);
+    // SVC1 AAAA positive → move-on criteria met, first attempt uses
+    // the redirected target name's resolved address.
+    he.input(
+        Input::DnsResult {
+            id: Id::from(3),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
+        },
+        now,
+    );
+    he.expect(
+        Output::AttemptConnection {
+            id: Id::from(5),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR_2.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H3,
+                ech_config: None,
+            },
+            is_ech_retry: false,
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    // Remaining DNS arrives while first attempt is in progress
+    he.input(
+        Input::DnsResult {
+            id: Id::from(4),
+            result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
     // Remaining attempts: SVC1's V4 address, then origin fallback.
     // SVC1 (priority 1) addresses come before the origin fallback.
     he.expect_connection_attempts(
-        &mut now,
         vec![
             // SVC1 bucket (priority 1)
             Output::AttemptConnection {
@@ -1328,6 +1156,7 @@ fn target_name_redirect_addresses_used_in_connection_attempts() {
             out_attempt_v6_h1_h2(Id::from(7)),
             out_attempt_v4_h1_h2(Id::from(8)),
         ],
+        &mut now,
     );
 }
 
@@ -1349,34 +1178,26 @@ fn https_fallback_uses_default_http_versions() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            // HTTPS record with port=8443, alpn=h3 only
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H3]).port(CUSTOM_PORT),
-                    ])),
-                }),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_negative(Id::from(1))),
-                Some(out_resolution_delay()),
-            ),
-            // Positive A: connection attempt uses port 8443 with H3 from HTTPS record
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_attempt_v4_h3_custom_port(Id::from(3))),
-            ),
-            (None, Some(out_connection_attempt_delay())),
-        ],
+    // HTTPS record with port=8443, alpn=h3 only
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H3]).port(CUSTOM_PORT),
+            ])),
+        },
         now,
     );
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_negative(Id::from(1)), now);
+    he.expect(out_resolution_delay(), now);
+    // Positive A: connection attempt uses port 8443 with H3 from HTTPS record
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_attempt_v4_h3_custom_port(Id::from(3)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
     // Fallback on port 443 must use default H2OrH1, NOT H3.
-    he.expect_connection_attempts(&mut now, vec![out_attempt_v4_h1_h2(Id::from(4))]);
+    he.expect_connection_attempts(vec![out_attempt_v4_h1_h2(Id::from(4))], &mut now);
 }
 
 /// When a connection attempt fails with `EchRetry`, the state machine should
@@ -1394,51 +1215,52 @@ fn ech_retry_same_endpoint() {
     let new_ech_config = EchConfig::new(vec![10, 20, 30, 40, 50]);
 
     expect_initial_dns_queries(&mut he, now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H2]).ech(),
+            ])),
+        },
+        now,
+    );
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    // First connection attempt with original ECH config.
     he.expect(
-        vec![
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H2]).ech(),
-                    ])),
-                }),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                // First connection attempt with original ECH config.
-                Some(Output::AttemptConnection {
-                    id: Id::from(3),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H2,
-                        ech_config: Some(ech_config()),
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-            (None, Some(out_connection_attempt_delay())),
-            // Server rejects ECH and provides retry_configs.
-            (
-                Some(Input::ConnectionResult {
-                    id: Id::from(3),
-                    result: ConnectionResult::EchRetry(new_ech_config.clone()),
-                }),
-                // State machine emits a new attempt with the new ECH config
-                // immediately (no delay — this is a server-initiated retry,
-                // not a new candidate).
-                Some(Output::AttemptConnection {
-                    id: Id::from(4),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H2,
-                        ech_config: Some(new_ech_config.clone()),
-                    },
-                    is_ech_retry: true,
-                }),
-            ),
-        ],
+        Output::AttemptConnection {
+            id: Id::from(3),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H2,
+                ech_config: Some(ech_config()),
+            },
+            is_ech_retry: false,
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    // Server rejects ECH and provides retry_configs.
+    he.input(
+        Input::ConnectionResult {
+            id: Id::from(3),
+            result: ConnectionResult::EchRetry(new_ech_config.clone()),
+        },
+        now,
+    );
+    // State machine emits a new attempt with the new ECH config
+    // immediately (no delay — this is a server-initiated retry,
+    // not a new candidate).
+    he.expect(
+        Output::AttemptConnection {
+            id: Id::from(4),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H2,
+                ech_config: Some(new_ech_config.clone()),
+            },
+            is_ech_retry: true,
+        },
         now,
     );
 }
@@ -1454,46 +1276,47 @@ fn ech_retry_without_ech_sets_flag() {
     let empty_ech_config = EchConfig::new(vec![]);
 
     expect_initial_dns_queries(&mut he, now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H2]).ech(),
+            ])),
+        },
+        now,
+    );
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
     he.expect(
-        vec![
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H2]).ech(),
-                    ])),
-                }),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(Output::AttemptConnection {
-                    id: Id::from(3),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H2,
-                        ech_config: Some(ech_config()),
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-            (None, Some(out_connection_attempt_delay())),
-            (
-                Some(Input::ConnectionResult {
-                    id: Id::from(3),
-                    result: ConnectionResult::EchRetry(empty_ech_config.clone()),
-                }),
-                Some(Output::AttemptConnection {
-                    id: Id::from(4),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H2,
-                        ech_config: Some(empty_ech_config.clone()),
-                    },
-                    is_ech_retry: true,
-                }),
-            ),
-        ],
+        Output::AttemptConnection {
+            id: Id::from(3),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H2,
+                ech_config: Some(ech_config()),
+            },
+            is_ech_retry: false,
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(
+        Input::ConnectionResult {
+            id: Id::from(3),
+            result: ConnectionResult::EchRetry(empty_ech_config.clone()),
+        },
+        now,
+    );
+    he.expect(
+        Output::AttemptConnection {
+            id: Id::from(4),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H2,
+                ech_config: Some(empty_ech_config.clone()),
+            },
+            is_ech_retry: true,
+        },
         now,
     );
 }
@@ -1513,71 +1336,74 @@ fn ech_retry_no_infinite_loop() {
     let retry_ech_config_2 = EchConfig::new(vec![60, 70, 80]);
 
     expect_initial_dns_queries(&mut he, now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, HOSTNAME, &[HttpVersion::H2]).ech(),
+            ])),
+        },
+        now,
+    );
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
     he.expect(
-        vec![
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, HOSTNAME, &[HttpVersion::H2]).ech(),
-                    ])),
-                }),
-                Some(out_resolution_delay()),
-            ),
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(Output::AttemptConnection {
-                    id: Id::from(3),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H2,
-                        ech_config: Some(ech_config()),
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-            (None, Some(out_connection_attempt_delay())),
-            // First EchRetry: accepted, new attempt emitted.
-            (
-                Some(Input::ConnectionResult {
-                    id: Id::from(3),
-                    result: ConnectionResult::EchRetry(retry_ech_config.clone()),
-                }),
-                Some(Output::AttemptConnection {
-                    id: Id::from(4),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V6_ADDR.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H2,
-                        ech_config: Some(retry_ech_config.clone()),
-                    },
-                    is_ech_retry: true,
-                }),
-            ),
-            (None, Some(out_connection_attempt_delay())),
-            // Second EchRetry on the retried attempt: ignored, treated as
-            // failure. A record still pending, so resolution delay.
-            (
-                Some(Input::ConnectionResult {
-                    id: Id::from(4),
-                    result: ConnectionResult::EchRetry(retry_ech_config_2),
-                }),
-                Some(out_resolution_delay()),
-            ),
-            // A record arrives, next endpoint attempted (V4, original ECH
-            // from DNS).
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(Output::AttemptConnection {
-                    id: Id::from(5),
-                    endpoint: Endpoint {
-                        address: SocketAddr::new(V4_ADDR.into(), PORT),
-                        http_version: ConnectionAttemptHttpVersions::H2,
-                        ech_config: Some(ech_config()),
-                    },
-                    is_ech_retry: false,
-                }),
-            ),
-        ],
+        Output::AttemptConnection {
+            id: Id::from(3),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H2,
+                ech_config: Some(ech_config()),
+            },
+            is_ech_retry: false,
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    // First EchRetry: accepted, new attempt emitted.
+    he.input(
+        Input::ConnectionResult {
+            id: Id::from(3),
+            result: ConnectionResult::EchRetry(retry_ech_config.clone()),
+        },
+        now,
+    );
+    he.expect(
+        Output::AttemptConnection {
+            id: Id::from(4),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V6_ADDR.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H2,
+                ech_config: Some(retry_ech_config.clone()),
+            },
+            is_ech_retry: true,
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    // Second EchRetry on the retried attempt: ignored, treated as
+    // failure. A record still pending, so resolution delay.
+    he.input(
+        Input::ConnectionResult {
+            id: Id::from(4),
+            result: ConnectionResult::EchRetry(retry_ech_config_2),
+        },
+        now,
+    );
+    he.expect(out_resolution_delay(), now);
+    // A record arrives, next endpoint attempted (V4, original ECH
+    // from DNS).
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(
+        Output::AttemptConnection {
+            id: Id::from(5),
+            endpoint: Endpoint {
+                address: SocketAddr::new(V4_ADDR.into(), PORT),
+                http_version: ConnectionAttemptHttpVersions::H2,
+                ech_config: Some(ech_config()),
+            },
+            is_ech_retry: false,
+        },
         now,
     );
 }
@@ -1616,86 +1442,80 @@ fn rfc_multi_cdn_target_names_resolved_and_attempted() {
     let (mut now, mut he) = setup();
 
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            // The CDN the customer is CNAME'd to returns two ServiceMode records,
-            // each steering to a different pool with its own target name.
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(0),
-                    result: DnsResult::Https(Ok(vec![
-                        service_info(1, H3POOL, &[HttpVersion::H3]),
-                        service_info(2, CDN1, &[HttpVersion::H2]),
-                    ])),
-                }),
-                // Both target names are resolved on their own.
-                Some(out_send_dns(Id::from(3), H3POOL, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(4), H3POOL, DnsRecordType::A)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(5), CDN1, DnsRecordType::Aaaa)),
-            ),
-            (
-                None,
-                Some(out_send_dns(Id::from(6), CDN1, DnsRecordType::A)),
-            ),
-            (None, Some(out_resolution_delay())),
-            // h3pool (priority 1) AAAA arrives -> first attempt uses the pool's
-            // own resolved address, never the origin's canonical name.
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(3),
-                    result: DnsResult::Aaaa(Ok(vec![H3POOL_V6])),
-                }),
-                Some(out_attempt(
-                    Id::from(7),
-                    H3POOL_V6.into(),
-                    PORT,
-                    ConnectionAttemptHttpVersions::H3,
-                )),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(4),
-                    result: DnsResult::A(Ok(vec![H3POOL_V4])),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(5),
-                    result: DnsResult::Aaaa(Ok(vec![CDN1_V6])),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(Input::DnsResult {
-                    id: Id::from(6),
-                    result: DnsResult::A(Ok(vec![CDN1_V4])),
-                }),
-                Some(out_connection_attempt_delay()),
-            ),
-            // Origin A/AAAA: the non-CDN fallback addresses.
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_connection_attempt_delay()),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
+    // The CDN the customer is CNAME'd to returns two ServiceMode records,
+    // each steering to a different pool with its own target name.
+    he.input(
+        Input::DnsResult {
+            id: Id::from(0),
+            result: DnsResult::Https(Ok(vec![
+                service_info(1, H3POOL, &[HttpVersion::H3]),
+                service_info(2, CDN1, &[HttpVersion::H2]),
+            ])),
+        },
+        now,
+    );
+    // Both target names are resolved on their own.
+    he.expect_all(
+        [
+            out_send_dns(Id::from(3), H3POOL, DnsRecordType::Aaaa),
+            out_send_dns(Id::from(4), H3POOL, DnsRecordType::A),
+            out_send_dns(Id::from(5), CDN1, DnsRecordType::Aaaa),
+            out_send_dns(Id::from(6), CDN1, DnsRecordType::A),
+            out_resolution_delay(),
         ],
         now,
     );
+    // h3pool (priority 1) AAAA arrives -> first attempt uses the pool's
+    // own resolved address, never the origin's canonical name.
+    he.input(
+        Input::DnsResult {
+            id: Id::from(3),
+            result: DnsResult::Aaaa(Ok(vec![H3POOL_V6])),
+        },
+        now,
+    );
+    he.expect(
+        out_attempt(
+            Id::from(7),
+            H3POOL_V6.into(),
+            PORT,
+            ConnectionAttemptHttpVersions::H3,
+        ),
+        now,
+    );
+    he.input(
+        Input::DnsResult {
+            id: Id::from(4),
+            result: DnsResult::A(Ok(vec![H3POOL_V4])),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(5),
+            result: DnsResult::Aaaa(Ok(vec![CDN1_V6])),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(6),
+            result: DnsResult::A(Ok(vec![CDN1_V4])),
+        },
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+    // Origin A/AAAA: the non-CDN fallback addresses.
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_connection_attempt_delay(), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
     // Remaining attempts: the rest of the priority-1 pool, then the priority-2
     // pool, then the origin fallback last.
     he.expect_connection_attempts(
-        &mut now,
         vec![
             // h3pool pool (priority 1): alpn="h3" -> H3 only.
             out_attempt(
@@ -1721,5 +1541,6 @@ fn rfc_multi_cdn_target_names_resolved_and_attempted() {
             out_attempt_v6_h1_h2(Id::from(11)),
             out_attempt_v4_h1_h2(Id::from(12)),
         ],
+        &mut now,
     );
 }

--- a/tests/https_records.rs
+++ b/tests/https_records.rs
@@ -118,7 +118,7 @@ fn hints_discarded_on_negative_answer() {
         );
         he.expect(case.attempt_1, now);
 
-        he.expect_connection_attempts(vec![case.attempt_2, case.attempt_3], &mut now);
+        he.expect_connection_attempts([case.attempt_2, case.attempt_3], &mut now);
     }
 }
 
@@ -172,7 +172,7 @@ fn ech_disabled() {
 
     // Origin fallback is NOT skipped despite HTTPS record having ECH.
     he.expect_connection_attempts(
-        vec![Output::AttemptConnection {
+        [Output::AttemptConnection {
             id: Id::from(4),
             endpoint: Endpoint {
                 address: SocketAddr::new(V6_ADDR.into(), PORT),
@@ -399,7 +399,7 @@ fn both_service_infos_have_ech_no_origin_fallback() {
     // own record's ALPN: SVC1 is H3-only, SVC2 is H2-only. Origin fallback is
     // skipped — no ECH on the origin.
     he.expect_connection_attempts(
-        vec![
+        [
             // priority=2 (SVC2, port 10443, ech, alpn=h2)
             Output::AttemptConnection {
                 id: Id::from(8),
@@ -496,7 +496,7 @@ fn per_record_alpn_not_unioned_across_records() {
     he.expect(out_connection_attempt_delay(), now);
 
     he.expect_connection_attempts(
-        vec![
+        [
             // svc2 (alpn=h2): H2-only, no spurious H3 from svc1's record.
             out_attempt(
                 Id::from(8),
@@ -594,7 +594,7 @@ fn record_without_alpn_contributes_no_endpoints() {
 
     // svc2 has no ALPN, so it produces no endpoints (its resolved V6_ADDR_3 is
     // never attempted). Only svc1's H3 attempt and the origin fallback remain.
-    he.expect_connection_attempts(vec![out_attempt_v6_h1_h2(Id::from(8))], &mut now);
+    he.expect_connection_attempts([out_attempt_v6_h1_h2(Id::from(8))], &mut now);
 }
 
 /// Partial ECH with an alt-svc record on the origin. Both alt-svc and origin
@@ -782,7 +782,7 @@ fn https_port_svcparam_applies_but_fallbacks_follow() {
     // Connection attempts using custom port: V4:H3, V6:H2, V4:H2, then
     // fallback on port 443 with default HTTP versions (H2OrH1).
     he.expect_connection_attempts(
-        vec![
+        [
             out_attempt_v4_h3_custom_port(Id::from(4)),
             out_attempt_v6_h2_custom_port(Id::from(5)),
             out_attempt_v4_h2_custom_port(Id::from(6)),
@@ -849,7 +849,7 @@ fn https_two_service_infos_with_different_ports() {
     he.expect(out_connection_attempt_delay(), now);
 
     he.expect_connection_attempts(
-        vec![
+        [
             // Priority-1 bucket (port 20007): V4:H3, V6:H2, V4:H2.
             attempt(4, V4_ADDR.into(), PORT_1, ConnectionAttemptHttpVersions::H3),
             attempt(5, V6_ADDR.into(), PORT_1, ConnectionAttemptHttpVersions::H2),
@@ -954,7 +954,7 @@ fn https_svc1_addresses_trigger_additional_attempts() {
     // come before P2 (SVC1, priority=2) endpoints.  V6_ADDR:H3 was already
     // attempted (id=5); the remaining follow in priority order, then fallback.
     he.expect_connection_attempts(
-        vec![
+        [
             attempt(6, V4_ADDR.into(), ConnectionAttemptHttpVersions::H3), // priority=1
             attempt(7, V6_ADDR.into(), ConnectionAttemptHttpVersions::H2), // priority=1
             attempt(8, V4_ADDR.into(), ConnectionAttemptHttpVersions::H2), // priority=1
@@ -1019,7 +1019,7 @@ fn https_port_takes_precedence_over_alt_svc_port() {
     he.expect(out_connection_attempt_delay(), now);
 
     he.expect_connection_attempts(
-        vec![
+        [
             // HTTPS bucket (port 8443)
             out_attempt(
                 Id::from(4),
@@ -1141,7 +1141,7 @@ fn target_name_redirect_addresses_used_in_connection_attempts() {
     // Remaining attempts: SVC1's V4 address, then origin fallback.
     // SVC1 (priority 1) addresses come before the origin fallback.
     he.expect_connection_attempts(
-        vec![
+        [
             // SVC1 bucket (priority 1)
             Output::AttemptConnection {
                 id: Id::from(6),
@@ -1197,7 +1197,7 @@ fn https_fallback_uses_default_http_versions() {
     he.expect(out_connection_attempt_delay(), now);
 
     // Fallback on port 443 must use default H2OrH1, NOT H3.
-    he.expect_connection_attempts(vec![out_attempt_v4_h1_h2(Id::from(4))], &mut now);
+    he.expect_connection_attempts([out_attempt_v4_h1_h2(Id::from(4))], &mut now);
 }
 
 /// When a connection attempt fails with `EchRetry`, the state machine should
@@ -1516,7 +1516,7 @@ fn rfc_multi_cdn_target_names_resolved_and_attempted() {
     // Remaining attempts: the rest of the priority-1 pool, then the priority-2
     // pool, then the origin fallback last.
     he.expect_connection_attempts(
-        vec![
+        [
             // h3pool pool (priority 1): alpn="h3" -> H3 only.
             out_attempt(
                 Id::from(8),

--- a/tests/network_config.rs
+++ b/tests/network_config.rs
@@ -13,7 +13,7 @@ fn ip_host() {
     let now = Instant::now();
     let mut he = HappyEyeballs::new("[2001:0DB8::1]", PORT).unwrap();
 
-    he.expect(vec![(None, Some(out_attempt_v6_h1_h2(Id::from(0))))], now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(0)), now);
 }
 
 #[test]
@@ -37,7 +37,7 @@ fn alt_svc_construction() {
     let mut he = HappyEyeballs::new_with_network_config(HOSTNAME, PORT, config).unwrap();
 
     // Should still send DNS queries as normal
-    he.expect(vec![(None, Some(out_send_dns_https(Id::from(0))))], now);
+    he.expect(out_send_dns_https(Id::from(0)), now);
 }
 
 #[test]
@@ -55,20 +55,11 @@ fn alt_svc_used_immediately() {
 
     // Alt-svc with H3 should make H3 available even without HTTPS DNS response
     expect_initial_dns_queries(&mut he, now);
-    he.expect(
-        vec![
-            (
-                Some(in_dns_https_negative(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            // Alt-svc provided H3, so we should attempt H3 connection
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt_v6_h3(Id::from(3))),
-            ),
-        ],
-        now,
-    );
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    // Alt-svc provided H3, so we should attempt H3 connection
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h3(Id::from(3)), now);
 }
 
 /// Alt-svc with a custom port: connections are attempted at both the alt-svc
@@ -92,32 +83,23 @@ fn alt_svc_with_port() {
     let (mut now, mut he) = setup_with_config(config);
 
     expect_initial_dns_queries(&mut he, now);
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    // AAAA arrives, move-on met. First endpoint: alt-svc port V6:H3
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
     he.expect(
-        vec![
-            (
-                Some(in_dns_https_negative(Id::from(0))),
-                Some(out_resolution_delay()),
-            ),
-            // AAAA arrives, move-on met. First endpoint: alt-svc port V6:H3
-            (
-                Some(in_dns_aaaa_positive(Id::from(1))),
-                Some(out_attempt(
-                    Id::from(3),
-                    V6_ADDR.into(),
-                    alt_port,
-                    ConnectionAttemptHttpVersions::H3,
-                )),
-            ),
-            (
-                Some(in_dns_a_positive(Id::from(2))),
-                Some(out_connection_attempt_delay()),
-            ),
-        ],
+        out_attempt(
+            Id::from(3),
+            V6_ADDR.into(),
+            alt_port,
+            ConnectionAttemptHttpVersions::H3,
+        ),
         now,
     );
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_connection_attempt_delay(), now);
 
     he.expect_connection_attempts(
-        &mut now,
         vec![
             // Alt-svc bucket (port 8443): V4:H3
             out_attempt(
@@ -140,22 +122,16 @@ fn alt_svc_with_port() {
                 ConnectionAttemptHttpVersions::H2OrH1,
             ),
         ],
+        &mut now,
     );
 
     // All connection attempts fail -> should report Failed(Connection)
     for id in 3..=5 {
-        he.expect(
-            vec![(Some(in_connection_result_negative(Id::from(id))), None)],
-            now,
-        );
+        he.input(in_connection_result_negative(Id::from(id)), now);
+        he.expect_idle(now);
     }
-    he.expect(
-        vec![(
-            Some(in_connection_result_negative(Id::from(6))),
-            Some(Output::Failed(FailureReason::Connection)),
-        )],
-        now,
-    );
+    he.input(in_connection_result_negative(Id::from(6)), now);
+    he.expect(Output::Failed(FailureReason::Connection), now);
 }
 
 /// When the host is an IP address and alt-svc specifies a custom port,
@@ -178,25 +154,19 @@ fn ip_host_alt_svc_with_port() {
     let mut he =
         HappyEyeballs::new_with_network_config(&V4_ADDR.to_string(), PORT, config).unwrap();
 
+    // Alt-svc bucket (port 8443): H3
     he.expect(
-        vec![
-            // Alt-svc bucket (port 8443): H3
-            (
-                None,
-                Some(out_attempt(
-                    Id::from(0),
-                    V4_ADDR.into(),
-                    CUSTOM_PORT,
-                    ConnectionAttemptHttpVersions::H3,
-                )),
-            ),
-            (None, Some(out_connection_attempt_delay())),
-        ],
+        out_attempt(
+            Id::from(0),
+            V4_ADDR.into(),
+            CUSTOM_PORT,
+            ConnectionAttemptHttpVersions::H3,
+        ),
         now,
     );
+    he.expect(out_connection_attempt_delay(), now);
 
     he.expect_connection_attempts(
-        &mut now,
         vec![
             // Fallback bucket (port 443): H2OrH1
             out_attempt(
@@ -206,6 +176,7 @@ fn ip_host_alt_svc_with_port() {
                 ConnectionAttemptHttpVersions::H2OrH1,
             ),
         ],
+        &mut now,
     );
 }
 
@@ -223,30 +194,23 @@ fn custom_delays() {
     });
 
     expect_initial_dns_queries(&mut he, now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    // Should use the custom resolution delay, not the default 50ms.
     he.expect(
-        vec![(
-            Some(in_dns_a_positive(Id::from(2))),
-            // Should use the custom resolution delay, not the default 50ms.
-            Some(Output::Timer {
-                duration: custom_resolution_delay,
-            }),
-        )],
+        Output::Timer {
+            duration: custom_resolution_delay,
+        },
         now,
     );
 
     now += custom_resolution_delay;
 
+    he.expect(out_attempt_v4_h1_h2(Id::from(3)), now);
+    // Should use the custom connection attempt delay, not the default 250ms.
     he.expect(
-        vec![
-            (None, Some(out_attempt_v4_h1_h2(Id::from(3)))),
-            // Should use the custom connection attempt delay, not the default 250ms.
-            (
-                None,
-                Some(Output::Timer {
-                    duration: custom_connection_attempt_delay,
-                }),
-            ),
-        ],
+        Output::Timer {
+            duration: custom_connection_attempt_delay,
+        },
         now,
     );
 }
@@ -290,15 +254,7 @@ fn assert_alt_svc_version_disabled(
     )
     .unwrap();
     he.expect(
-        vec![(
-            None,
-            Some(out_attempt(
-                Id::from(0),
-                V4_ADDR.into(),
-                PORT,
-                expected_fallback,
-            )),
-        )],
+        out_attempt(Id::from(0), V4_ADDR.into(), PORT, expected_fallback),
         now,
     );
 }

--- a/tests/network_config.rs
+++ b/tests/network_config.rs
@@ -100,7 +100,7 @@ fn alt_svc_with_port() {
     he.expect(out_connection_attempt_delay(), now);
 
     he.expect_connection_attempts(
-        vec![
+        [
             // Alt-svc bucket (port 8443): V4:H3
             out_attempt(
                 Id::from(4),
@@ -167,7 +167,7 @@ fn ip_host_alt_svc_with_port() {
     he.expect(out_connection_attempt_delay(), now);
 
     he.expect_connection_attempts(
-        vec![
+        [
             // Fallback bucket (port 443): H2OrH1
             out_attempt(
                 Id::from(1),

--- a/tests/type_impls.rs
+++ b/tests/type_impls.rs
@@ -77,13 +77,8 @@ fn happy_eyeballs_debug() {
     // Drive through DNS queries, feed HTTPS+ECH and AAAA to get a connection
     // attempt that carries ECH config.
     expect_initial_dns_queries(&mut he2, now2);
-    he2.expect(
-        vec![(
-            Some(in_dns_https_positive_ech(Id::from(0))),
-            Some(out_resolution_delay()),
-        )],
-        now2,
-    );
+    he2.input(in_dns_https_positive_ech(Id::from(0)), now2);
+    he2.expect(out_resolution_delay(), now2);
 
     // AAAA arrives; connection attempt with ECH is emitted.
     he2.process_input(in_dns_aaaa_positive(Id::from(1)), now2);


### PR DESCRIPTION
The `HappyEyeballsExt::expect` helper took a
`Vec<(Option<Input>, Option<Output>)>`, coupling each input with an output
even though feeding an input and asserting an output are independent
operations. Replace it with independent driver methods, all taking `now`
last:

- `input(input, now)` feeds one input,
- `expect(output, now)` consumes one `process_output` and asserts it,
- `expect_all(outputs, now)` asserts a run of consecutive outputs,
- `expect_idle(now)` asserts no further output.

Each former tuple maps one-to-one onto these calls, so the exact sequence
of `process_input`/`process_output` calls and assertions is preserved.
Data-driven optional steps now read as plain `if let`/`match`. The
repeated SVC target-resolution bursts are factored into
`expect_svc1_dns_queries` / `expect_svc1_svc2_dns_queries`, paralleling
`expect_initial_dns_queries`.