### PR TITLE
Add config flag to skip waiting for the preferred address family

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,11 +604,11 @@ pub struct NetworkConfig {
     /// out the [`resolution_delay`](Self::resolution_delay).
     ///
     /// When `false`, that requirement is dropped: once positive address answers
-    /// and SVCB/HTTPS service information are available, the state machine moves
-    /// on without waiting for the preferred address family answer (and thus
-    /// without the resolution delay when the non-preferred family arrives
-    /// first). The delay still applies while SVCB/HTTPS information is
-    /// outstanding.
+    /// have been received and the SVCB/HTTPS query has completed (whether with a
+    /// positive or a negative response), the state machine moves on without
+    /// waiting for the preferred address family answer (and thus without the
+    /// resolution delay when the non-preferred family arrives first). The delay
+    /// still applies while the SVCB/HTTPS query is outstanding.
     ///
     /// Defaults to `true`, matching
     /// <https://www.ietf.org/archive/id/draft-ietf-happy-happyeyeballs-v3-02.html#section-4.2>.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -594,6 +594,25 @@ pub struct NetworkConfig {
     ///
     /// Defaults to `true`.
     pub ech: bool,
+    /// Whether to wait for an answer for the preferred address family before
+    /// moving on to the connection phase.
+    ///
+    /// Per the spec, moving on without waiting out the resolution delay
+    /// requires a positive or negative answer for the preferred address family
+    /// (e.g. AAAA when IPv6 is preferred). When that answer is slow to arrive,
+    /// a client that already has the non-preferred family (e.g. A) still waits
+    /// out the [`resolution_delay`](Self::resolution_delay).
+    ///
+    /// When `false`, that requirement is dropped: once positive address answers
+    /// and SVCB/HTTPS service information are available, the state machine moves
+    /// on without waiting for the preferred address family answer (and thus
+    /// without the resolution delay when the non-preferred family arrives
+    /// first). The delay still applies while SVCB/HTTPS information is
+    /// outstanding.
+    ///
+    /// Defaults to `true`, matching
+    /// <https://www.ietf.org/archive/id/draft-ietf-happy-happyeyeballs-v3-02.html#section-4.2>.
+    pub wait_for_preferred_address: bool,
 }
 
 impl Default for NetworkConfig {
@@ -605,6 +624,7 @@ impl Default for NetworkConfig {
             resolution_delay: RESOLUTION_DELAY,
             connection_attempt_delay: CONNECTION_ATTEMPT_DELAY,
             ech: true,
+            wait_for_preferred_address: true,
         }
     }
 }
@@ -1468,11 +1488,16 @@ impl HappyEyeballs {
         // > for the preferred address family that was queried AND
         //
         // <https://www.ietf.org/archive/id/draft-ietf-happy-happyeyeballs-v3-02.html#section-4.2>
-        if !self
-            .dns_queries
-            .iter()
-            .filter(|q| q.is_completed())
-            .any(|q| q.record_type == self.network_config.preferred_dns_record_type())
+        //
+        // Skipped when `wait_for_preferred_address` is disabled, letting the
+        // state machine move on with the non-preferred family rather than
+        // waiting out the resolution delay for the preferred one.
+        if self.network_config.wait_for_preferred_address
+            && !self
+                .dns_queries
+                .iter()
+                .filter(|q| q.is_completed())
+                .any(|q| q.record_type == self.network_config.preferred_dns_record_type())
         {
             return false;
         }

--- a/tests/network_config.rs
+++ b/tests/network_config.rs
@@ -235,6 +235,29 @@ fn skip_wait_for_preferred_address() {
     he.expect(out_connection_attempt_delay(), now);
 }
 
+/// Symmetric to [`skip_wait_for_preferred_address`] but with
+/// `DualStackPreferV4`, so the preferred family is A and the non-preferred AAAA
+/// arrives first. With the flag disabled, the AAAA answer plus an HTTPS answer
+/// is enough to move on, without waiting out the resolution delay for the
+/// preferred family (A).
+#[test]
+fn skip_wait_for_preferred_address_v4_preferred() {
+    let (now, mut he) = setup_with_config(NetworkConfig {
+        ip: IpPreference::DualStackPreferV4,
+        wait_for_preferred_address: false,
+        ..NetworkConfig::default()
+    });
+
+    expect_initial_dns_queries(&mut he, now);
+    // HTTPS answer arrives, then AAAA. A (the preferred family) is still
+    // outstanding, but with the flag disabled we move on immediately instead of
+    // arming the resolution-delay timer.
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.expect(out_connection_attempt_delay(), now);
+}
+
 /// `wait_for_preferred_address` only drops the wait for the preferred family.
 /// The resolution delay still applies while the HTTPS answer is outstanding.
 #[test]

--- a/tests/network_config.rs
+++ b/tests/network_config.rs
@@ -215,6 +215,42 @@ fn custom_delays() {
     );
 }
 
+/// With `wait_for_preferred_address` disabled, the non-preferred family (A)
+/// plus an HTTPS answer is enough to move on, without waiting out the
+/// resolution delay for the preferred family (AAAA).
+#[test]
+fn skip_wait_for_preferred_address() {
+    let (now, mut he) = setup_with_config(NetworkConfig {
+        wait_for_preferred_address: false,
+        ..NetworkConfig::default()
+    });
+
+    expect_initial_dns_queries(&mut he, now);
+    // HTTPS answer arrives, then A. AAAA (the preferred family) is still
+    // outstanding, but with the flag disabled we move on immediately instead of
+    // arming the resolution-delay timer.
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_attempt_v4_h1_h2(Id::from(3)), now);
+    he.expect(out_connection_attempt_delay(), now);
+}
+
+/// `wait_for_preferred_address` only drops the wait for the preferred family.
+/// The resolution delay still applies while the HTTPS answer is outstanding.
+#[test]
+fn skip_wait_for_preferred_address_still_waits_for_https() {
+    let (now, mut he) = setup_with_config(NetworkConfig {
+        wait_for_preferred_address: false,
+        ..NetworkConfig::default()
+    });
+
+    expect_initial_dns_queries(&mut he, now);
+    // Only A has arrived; HTTPS and AAAA are still outstanding. Without the
+    // HTTPS answer we must not move on, so the resolution-delay timer is armed.
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
+}
+
 /// Config with `version` disabled in `http_versions` and present as the sole alt-svc entry.
 fn alt_svc_disabled_config(version: HttpVersion) -> NetworkConfig {
     let http_versions = match version {


### PR DESCRIPTION
Per the spec, moving on without the resolution delay requires an answer for the preferred address family (e.g. AAAA when IPv6 is preferred). When that answer is slow, a client that already has the non-preferred family (e.g. A) plus HTTPS service information still waits out the resolution delay.

Add `NetworkConfig::wait_for_preferred_address` (default `true`, keeping spec-compliant behavior). When `false`, the preferred-family requirement is dropped: once positive address answers and SVCB/HTTPS information are available, the state machine moves on without waiting for the preferred family, and thus without the resolution delay when the non-preferred family arrives first. The delay still applies while HTTPS information is outstanding.

Closes #115

//CC @larseggert: note this introduces the config flag only, it still default to `true`, i.e. waiting for the preferred address.