### PR TITLE
Add configurable connection attempt delay multiplier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::num::NonZeroU32;
 use std::time::{Duration, Instant};
 
 use log::trace;
@@ -72,6 +73,11 @@ pub const RESOLUTION_DELAY: Duration = Duration::from_millis(50);
 ///
 /// <https://www.ietf.org/archive/id/draft-ietf-happy-happyeyeballs-v3-02.html#section-9>
 pub const CONNECTION_ATTEMPT_DELAY: Duration = Duration::from_millis(250);
+
+/// The default multiplier applied to the connection attempt delay after each
+/// successive attempt. A value of `1` keeps the delay constant, matching the
+/// RFC behavior.
+pub const CONNECTION_ATTEMPT_DELAY_MULTIPLIER: NonZeroU32 = NonZeroU32::MIN;
 
 /// Input events to the Happy Eyeballs state machine
 #[derive(Debug, Clone, PartialEq)]
@@ -587,6 +593,23 @@ pub struct NetworkConfig {
     /// Defaults to [`CONNECTION_ATTEMPT_DELAY`] (250 ms) per
     /// <https://www.ietf.org/archive/id/draft-ietf-happy-happyeyeballs-v3-02.html#section-9>.
     pub connection_attempt_delay: Duration,
+    /// Multiplier applied to [`connection_attempt_delay`](Self::connection_attempt_delay)
+    /// as concurrent connection attempts pile up, growing the delay
+    /// exponentially.
+    ///
+    /// The delay before starting another attempt while `n` attempts are already
+    /// in progress is `connection_attempt_delay * multiplier^(n - 1)`. With a
+    /// base delay of 250 ms and a multiplier of `2`, racing attempts are
+    /// scheduled at `t=0`, `t=250`, `t=750`, `t=1750`, ... (intervals of 250,
+    /// 500, 1000 ms). This lets callers lower the base delay below the
+    /// RFC-recommended 250 ms while still backing off between attempts.
+    ///
+    /// Only in-progress attempts count, so attempts triggered by a previous
+    /// attempt failing do not grow the delay.
+    ///
+    /// Defaults to [`CONNECTION_ATTEMPT_DELAY_MULTIPLIER`] (`1`), which keeps the
+    /// delay constant per the RFC.
+    pub connection_attempt_delay_multiplier: NonZeroU32,
     /// Whether Encrypted Client Hello (ECH) is enabled.
     ///
     /// When `false`, ECH configs from HTTPS records are ignored: endpoints
@@ -605,6 +628,7 @@ impl Default for NetworkConfig {
             alt_svc: Vec::new(),
             resolution_delay: RESOLUTION_DELAY,
             connection_attempt_delay: CONNECTION_ATTEMPT_DELAY,
+            connection_attempt_delay_multiplier: CONNECTION_ATTEMPT_DELAY_MULTIPLIER,
             ech: true,
         }
     }
@@ -868,6 +892,32 @@ impl HappyEyeballs {
         None
     }
 
+    /// The delay to wait before starting the next connection attempt, growing
+    /// exponentially with the number of attempts currently in progress per the
+    /// configured [`connection_attempt_delay_multiplier`](NetworkConfig::connection_attempt_delay_multiplier).
+    ///
+    /// Only in-progress (racing) attempts count: an attempt that has already
+    /// failed does not inflate the delay, so a sequence of attempts each
+    /// triggered by the previous one failing keeps the base delay.
+    fn connection_attempt_delay(&self) -> Duration {
+        let base = self.network_config.connection_attempt_delay;
+        let in_progress = self
+            .connection_attempts
+            .iter()
+            .filter(|a| a.state == ConnectionState::InProgress)
+            .count();
+        let exponent = u32::try_from(in_progress)
+            .unwrap_or(u32::MAX)
+            .saturating_sub(1);
+        let factor = self
+            .network_config
+            .connection_attempt_delay_multiplier
+            .get()
+            .checked_pow(exponent)
+            .unwrap_or(u32::MAX);
+        base.checked_mul(factor).unwrap_or(Duration::MAX)
+    }
+
     fn delay(&self, now: Instant) -> Option<Output> {
         // If we have a successful connection, no connection attempt delay
         // needed.
@@ -875,7 +925,8 @@ impl HappyEyeballs {
             return None;
         }
 
-        if let Some(connection_attempt_delay) = self
+        let connection_attempt_delay = self.connection_attempt_delay();
+        if let Some(remaining) = self
             .connection_attempts
             .iter()
             .filter(|a| a.state == ConnectionState::InProgress)
@@ -883,15 +934,15 @@ impl HappyEyeballs {
             .max()
             .and_then(|started| {
                 let elapsed = now.duration_since(*started);
-                if elapsed < self.network_config.connection_attempt_delay {
-                    Some(self.network_config.connection_attempt_delay - elapsed)
+                if elapsed < connection_attempt_delay {
+                    Some(connection_attempt_delay - elapsed)
                 } else {
                     None
                 }
             })
         {
             return Some(Output::Timer {
-                duration: connection_attempt_delay,
+                duration: remaining,
             });
         }
 
@@ -1125,11 +1176,12 @@ impl HappyEyeballs {
             return None;
         }
 
+        let connection_attempt_delay = self.connection_attempt_delay();
         if self
             .connection_attempts
             .iter()
             .filter(|a| a.state == ConnectionState::InProgress)
-            .any(|a| a.within_delay(now, self.network_config.connection_attempt_delay))
+            .any(|a| a.within_delay(now, connection_attempt_delay))
         {
             return None;
         }

--- a/tests/connection_attempts.rs
+++ b/tests/connection_attempts.rs
@@ -4,7 +4,7 @@
 mod common;
 use common::*;
 
-use std::{net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, num::NonZeroU32, time::Duration};
 
 use happy_eyeballs::{
     CONNECTION_ATTEMPT_DELAY, ConnectionAttemptHttpVersions, DnsResult, Endpoint, Id, Input,
@@ -49,6 +49,80 @@ fn connection_attempt_delay() {
     now += CONNECTION_ATTEMPT_DELAY;
 
     he.expect(out_attempt_v4_h1_h2(Id::from(4)), now);
+}
+
+/// With a multiplier of 2, the delay before each successive connection attempt
+/// doubles: attempts land at t=0, t=250, t=750, t=1750.
+#[test]
+fn connection_attempt_delay_multiplier() {
+    let base = Duration::from_millis(250);
+    let (mut now, mut he) = setup_with_config(NetworkConfig {
+        connection_attempt_delay: base,
+        connection_attempt_delay_multiplier: NonZeroU32::new(2).unwrap(),
+        ..NetworkConfig::default()
+    });
+
+    expect_initial_dns_queries(&mut he, now);
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(1),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR, V6_ADDR_2, V6_ADDR_3])),
+        },
+        now,
+    );
+
+    // First attempt at t=0; one attempt in flight, so the next is one base
+    // delay away.
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.expect(Output::Timer { duration: base }, now);
+
+    // Second attempt at t=250 (after base * 2^0). The next delay then doubles.
+    now += base;
+    let second = he.process_output(now).unwrap().attempt().unwrap();
+    assert_eq!(second.address.ip(), V6_ADDR_2);
+    he.expect(Output::Timer { duration: base * 2 }, now);
+
+    // Third attempt at t=750 (after base * 2^1). The next delay doubles again.
+    now += base * 2;
+    let third = he.process_output(now).unwrap().attempt().unwrap();
+    assert_eq!(third.address.ip(), V6_ADDR_3);
+    he.expect(Output::Timer { duration: base * 4 }, now);
+}
+
+/// Attempts triggered by a previous attempt failing must not grow the delay:
+/// only concurrently in-progress attempts increase it. With one attempt in
+/// progress the delay stays at the base value even after an earlier failure.
+#[test]
+fn failed_attempts_do_not_increase_delay() {
+    let base = Duration::from_millis(250);
+    let (now, mut he) = setup_with_config(NetworkConfig {
+        connection_attempt_delay: base,
+        connection_attempt_delay_multiplier: NonZeroU32::new(2).unwrap(),
+        ..NetworkConfig::default()
+    });
+
+    expect_initial_dns_queries(&mut he, now);
+    he.input(in_dns_https_negative(Id::from(0)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(1),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR, V6_ADDR_2])),
+        },
+        now,
+    );
+
+    // First attempt, then fail it: the next attempt starts immediately.
+    he.expect(out_attempt_v6_h1_h2(Id::from(3)), now);
+    he.input(in_connection_result_negative(Id::from(3)), now);
+    let second = he.process_output(now).unwrap().attempt().unwrap();
+    assert_eq!(second.address.ip(), V6_ADDR_2);
+
+    // Only one attempt is in progress, so the delay stays at the base value
+    // rather than growing because a previous attempt failed.
+    he.expect(Output::Timer { duration: base }, now);
 }
 
 #[test]


### PR DESCRIPTION
Introduce a connection_attempt_delay_multiplier on NetworkConfig that grows the connection attempt delay exponentially with the number of concurrent in-progress attempts. The delay before starting another attempt while n attempts are in progress is connection_attempt_delay * multiplier^(n - 1). With a 250 ms base delay and a multiplier of 2, racing attempts are scheduled at t=0, t=250, t=750, t=1750.

Attempts triggered by a previous attempt failing do not grow the delay, since only in-progress attempts count. The multiplier defaults to 1, preserving the existing constant-delay behavior.