### PR TITLE
Handle alt-svc entries with a custom host

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,22 +165,6 @@ impl DnsResult {
             .map(IpAddr::V6)
             .chain(v4.iter().copied().map(IpAddr::V4))
     }
-
-    fn flatten_into_endpoints(
-        &self,
-        port: u16,
-        http_versions: &HashSet<ConnectionAttemptHttpVersions>,
-    ) -> Vec<Endpoint> {
-        self.ip_addrs()
-            .flat_map(|ip| {
-                http_versions.iter().map(move |v| Endpoint {
-                    address: SocketAddr::new(ip, port),
-                    http_version: *v,
-                    ech_config: None,
-                })
-            })
-            .collect()
-    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -961,6 +945,10 @@ impl HappyEyeballs {
             return Some(o);
         }
 
+        if let Some(o) = self.send_dns_request_for_alt_svc() {
+            return Some(o);
+        }
+
         if let Some(o) = self.delay(now) {
             return Some(o);
         }
@@ -1119,6 +1107,46 @@ impl HappyEyeballs {
             })?;
 
         let target_name = target_name.clone();
+        let id = self.id_generator.next_id();
+        self.dns_queries.push(DnsQuery {
+            id,
+            target_name: target_name.clone(),
+            record_type,
+            state: DnsQueryState::InProgress,
+        });
+        Some(Output::SendDnsQuery {
+            id,
+            hostname: target_name,
+            record_type,
+        })
+    }
+
+    /// A/AAAA queries for alt-svc entries that name a custom host.
+    ///
+    /// Alt-svc hosts that are IP literals need no resolution and are skipped.
+    fn send_dns_request_for_alt_svc(&mut self) -> Option<Output> {
+        let hosts = self
+            .network_config
+            .alt_svc
+            .iter()
+            .filter_map(|a| a.host.as_deref())
+            .filter(|h| h.parse::<IpAddr>().is_err());
+
+        let (target_name, record_type) = hosts
+            .flat_map(|h| {
+                self.network_config
+                    .ip
+                    .address_record_types()
+                    .map(move |rt| (h, rt))
+            })
+            .find(|(h, rt)| {
+                !self
+                    .dns_queries
+                    .iter()
+                    .any(|q| q.target_name.as_str() == *h && q.record_type == *rt)
+            })?;
+
+        let target_name: TargetName = target_name.into();
         let id = self.id_generator.next_id();
         self.dns_queries.push(DnsQuery {
             id,
@@ -1323,39 +1351,39 @@ impl HappyEyeballs {
     }
 
     fn endpoints_to_attempt(&self) -> Vec<Endpoint> {
-        match &self.host {
-            Host::Ip(ip) => self.endpoints_to_attempt_ip(*ip),
-            Host::Domain(domain) => self.endpoints_to_attempt_domain(domain),
+        let any_ech = self.any_ech();
+
+        // HTTPS-record endpoints come first, ordered by priority.
+        let mut endpoints = self.service_info_endpoints();
+
+        // Alt-svc and the plain origin fallback never carry ECH (an alt-svc
+        // target may differ from the origin), so when at least one ServiceInfo
+        // advertises ECH we use only the HTTPS-record endpoints above.
+        // Otherwise both are tried, after the HTTPS-record endpoints and
+        // interleaved together as a single tier by protocol and address family.
+        if !any_ech {
+            let mut tier = self.alt_svc_endpoints();
+            tier.extend(self.origin_fallback_endpoints());
+            endpoints.extend(interleave_endpoints(tier, self.network_config.prefer_v6()));
         }
+
+        endpoints
     }
 
-    fn endpoints_to_attempt_ip(&self, ip: IpAddr) -> Vec<Endpoint> {
-        let endpoints = self
-            .origin_version_port_pairs()
-            .into_iter()
-            .map(|(http_version, port)| Endpoint {
-                address: SocketAddr::new(ip, port),
-                http_version,
-                ech_config: None,
-            })
-            .collect();
-        interleave_endpoints(endpoints, self.network_config.prefer_v6())
-    }
-
-    fn endpoints_to_attempt_domain(&self, origin_domain: &str) -> Vec<Endpoint> {
+    /// Endpoints from completed HTTPS records, ordered by priority and
+    /// interleaved per record by protocol and address family.
+    fn service_info_endpoints(&self) -> Vec<Endpoint> {
         let any_ech = self.any_ech();
         let prefer_v6 = self.network_config.prefer_v6();
 
         // Collect all ServiceInfos sorted by priority.
         let mut service_infos: Vec<&ServiceInfo> = self
             .completed_service_infos()
-            // When at least one ServiceInfo has ECH config, skip those without it
-            // and skip the origin fallback.
+            // When at least one ServiceInfo has ECH config, skip those without it.
             .filter(|i| !any_ech || i.ech_config.is_some())
             .collect();
         service_infos.sort_by_key(|i| i.priority);
 
-        // build a sorted endpoints per ServiceInfo.
         let mut endpoints: Vec<Endpoint> = Vec::new();
         for info in &service_infos {
             let ipv4_addrs: Option<&[Ipv4Addr]> =
@@ -1386,30 +1414,6 @@ impl HappyEyeballs {
                 self.network_config.ech,
             );
             endpoints.extend(interleave_endpoints(bucket, prefer_v6));
-        }
-
-        // Alt-svc and fallback endpoints use the origin domain without ECH.
-        // Only include them when ECH is not required. They form a single group
-        // so that their protocol variants (e.g. an alt-svc HTTP/3 and the
-        // default HTTP/2) and address families are interleaved together.
-        if !any_ech {
-            let mut fallback: Vec<Endpoint> = Vec::new();
-            for (http_version, port) in self.origin_version_port_pairs() {
-                let http_versions = HashSet::from([http_version]);
-                fallback.extend(
-                    self.dns_queries
-                        .iter()
-                        .filter_map(|q| match &q.state {
-                            DnsQueryState::Completed {
-                                response: r @ (DnsResult::Aaaa(_) | DnsResult::A(_)),
-                                ..
-                            } if q.target_name.as_str() == origin_domain => Some(r),
-                            _ => None,
-                        })
-                        .flat_map(|r| r.flatten_into_endpoints(port, &http_versions)),
-                );
-            }
-            endpoints.extend(interleave_endpoints(fallback, prefer_v6));
         }
 
         endpoints
@@ -1486,19 +1490,20 @@ impl HappyEyeballs {
         self.ip_host_http_versions()
     }
 
-    /// (http_version, port) pairs for origin endpoints (alt-svc and defaults).
+    /// Endpoints for every alt-svc entry, flat (interleaved by the caller).
     ///
-    /// Combines:
-    /// 1. Alt-svc entries (custom port or origin port)
-    /// 2. Default HTTP versions (H2/H1) at the origin port
-    fn origin_version_port_pairs(&self) -> Vec<(ConnectionAttemptHttpVersions, u16)> {
-        let mut pairs = Vec::new();
-
+    /// Per [RFC 7838](https://datatracker.ietf.org/doc/html/rfc7838), an alt-svc
+    /// entry advertises the origin's service at a host (and optionally port) over
+    /// a given protocol. An entry without a host of its own simply defaults to
+    /// the origin host, so both kinds are handled the same way: the effective
+    /// host is resolved (or taken as an IP literal) and attempted at the alt-svc
+    /// port (defaulting to the origin port) over the alt-svc protocol.
+    ///
+    /// ECH is never applied: an alt-svc target may differ from the origin, so
+    /// the origin's HTTPS-record ECH config does not apply to it.
+    fn alt_svc_endpoints(&self) -> Vec<Endpoint> {
+        let mut endpoints = Vec::new();
         for alt_svc in &self.network_config.alt_svc {
-            debug_assert!(
-                alt_svc.host.is_none(),
-                "alt-svc with custom host not yet supported"
-            );
             if self
                 .network_config
                 .is_http_version_disabled(alt_svc.http_version)
@@ -1506,14 +1511,63 @@ impl HappyEyeballs {
                 continue;
             }
             let port = alt_svc.port.unwrap_or(self.port);
-            pairs.push((alt_svc.http_version.into(), port));
+            let http_version: ConnectionAttemptHttpVersions = alt_svc.http_version.into();
+            endpoints.extend(self.alt_svc_addrs(alt_svc).into_iter().map(|ip| Endpoint {
+                address: SocketAddr::new(ip, port),
+                http_version,
+                ech_config: None,
+            }));
         }
+        endpoints
+    }
 
-        for http_version in self.fallback_http_versions() {
-            pairs.push((http_version, self.port));
+    /// The default origin endpoints: the baseline H2/H1 connection at the origin
+    /// host and port, used when neither HTTPS records nor alt-svc apply. Flat
+    /// (interleaved by the caller).
+    fn origin_fallback_endpoints(&self) -> Vec<Endpoint> {
+        let http_versions = self.fallback_http_versions();
+        self.origin_addrs()
+            .into_iter()
+            .flat_map(|ip| {
+                http_versions.iter().map(move |&http_version| Endpoint {
+                    address: SocketAddr::new(ip, self.port),
+                    http_version,
+                    ech_config: None,
+                })
+            })
+            .collect()
+    }
+
+    /// Addresses for an alt-svc entry's effective host: its own host when set,
+    /// or the origin host otherwise.
+    fn alt_svc_addrs(&self, alt_svc: &AltSvc) -> Vec<IpAddr> {
+        match &alt_svc.host {
+            Some(host) => self.resolved_addrs(host),
+            None => self.origin_addrs(),
         }
+    }
 
-        pairs
+    /// Addresses for the origin host: the literal when it is an IP, otherwise
+    /// the addresses received for the origin's A/AAAA queries.
+    fn origin_addrs(&self) -> Vec<IpAddr> {
+        match &self.host {
+            Host::Ip(ip) => vec![*ip],
+            Host::Domain(domain) => self.resolved_addrs(domain),
+        }
+    }
+
+    /// Addresses for `host`: the literal when it is an IP, otherwise the
+    /// addresses received for its A/AAAA queries.
+    fn resolved_addrs(&self, host: &str) -> Vec<IpAddr> {
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            return vec![ip];
+        }
+        self.dns_queries
+            .iter()
+            .filter(|q| q.target_name.as_str() == host)
+            .filter_map(DnsQuery::response)
+            .flat_map(DnsResult::ip_addrs)
+            .collect()
     }
 
     /// Whether to move on to the connection attempt phase based on the received

--- a/tests/network_config.rs
+++ b/tests/network_config.rs
@@ -4,8 +4,8 @@ use common::*;
 use std::time::{Duration, Instant};
 
 use happy_eyeballs::{
-    AltSvc, ConnectionAttemptHttpVersions, DnsResult, FailureReason, HappyEyeballs, HttpVersion,
-    HttpVersions, Id, Input, IpPreference, NetworkConfig, Output,
+    AltSvc, ConnectionAttemptHttpVersions, DnsRecordType, DnsResult, FailureReason, HappyEyeballs,
+    HttpVersion, HttpVersions, Id, Input, IpPreference, NetworkConfig, Output,
 };
 
 #[test]
@@ -174,6 +174,223 @@ fn ip_host_alt_svc_with_port() {
                 V4_ADDR.into(),
                 PORT,
                 ConnectionAttemptHttpVersions::H2OrH1,
+            ),
+        ],
+        &mut now,
+    );
+}
+
+/// Alt-svc entry that names a custom host: the host gets its own A/AAAA
+/// queries and is attempted (at the alt-svc port, over the alt-svc protocol)
+/// ahead of the plain origin fallback.
+///
+/// Expected endpoint order:
+///   alt-svc host bucket (ALT_HOST, port 8443): V6_ADDR_2:H3, V4_ADDR_2:H3
+///   fallback bucket     (HOSTNAME, port  443): V6_ADDR:H2OrH1, V4_ADDR:H2OrH1
+#[test]
+fn alt_svc_with_host() {
+    const ALT_HOST: &str = "alt.example.com";
+    let config = NetworkConfig {
+        alt_svc: vec![AltSvc {
+            host: Some(ALT_HOST.to_string()),
+            port: Some(CUSTOM_PORT),
+            http_version: HttpVersion::H3,
+        }],
+        ..NetworkConfig::default()
+    };
+    let (mut now, mut he) = setup_with_config(config);
+
+    // Origin queries (ids 0-2), then the alt-svc host's AAAA/A queries (ids 3-4).
+    expect_initial_dns_queries(&mut he, now);
+    he.expect(
+        out_send_dns(Id::from(3), ALT_HOST, DnsRecordType::Aaaa),
+        now,
+    );
+    he.expect(out_send_dns(Id::from(4), ALT_HOST, DnsRecordType::A), now);
+    he.expect_idle(now);
+
+    // Resolve all address records first. Without the HTTPS answer the machine
+    // keeps waiting out the resolution delay.
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(3),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
+        },
+        now,
+    );
+    he.expect(out_resolution_delay(), now);
+    he.input(
+        Input::DnsResult {
+            id: Id::from(4),
+            result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+        },
+        now,
+    );
+    he.expect(out_resolution_delay(), now);
+
+    // The negative HTTPS answer completes the move-on conditions.
+    he.input(in_dns_https_negative(Id::from(0)), now);
+
+    // Alt-svc host endpoints (port 8443, H3) come first, then origin fallback.
+    he.expect(
+        out_attempt(
+            Id::from(5),
+            V6_ADDR_2.into(),
+            CUSTOM_PORT,
+            ConnectionAttemptHttpVersions::H3,
+        ),
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+
+    he.expect_connection_attempts(
+        [
+            out_attempt(
+                Id::from(6),
+                V4_ADDR_2.into(),
+                CUSTOM_PORT,
+                ConnectionAttemptHttpVersions::H3,
+            ),
+            out_attempt(
+                Id::from(7),
+                V6_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H2OrH1,
+            ),
+            out_attempt(
+                Id::from(8),
+                V4_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H2OrH1,
+            ),
+        ],
+        &mut now,
+    );
+}
+
+/// An alt-svc host that is already an IP literal needs no DNS resolution: it is
+/// attempted directly, ahead of the plain origin fallback.
+#[test]
+fn alt_svc_host_ip_literal() {
+    let config = NetworkConfig {
+        alt_svc: vec![AltSvc {
+            host: Some(V4_ADDR_2.to_string()),
+            port: Some(CUSTOM_PORT),
+            http_version: HttpVersion::H3,
+        }],
+        ..NetworkConfig::default()
+    };
+    let (mut now, mut he) = setup_with_config(config);
+
+    // No extra DNS query is issued for the IP-literal alt-svc host.
+    expect_initial_dns_queries(&mut he, now);
+    he.expect_idle(now);
+
+    he.input(in_dns_aaaa_positive(Id::from(1)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_a_positive(Id::from(2)), now);
+    he.expect(out_resolution_delay(), now);
+    he.input(in_dns_https_negative(Id::from(0)), now);
+
+    // Alt-svc host (the IP literal) first, then origin fallback.
+    he.expect(
+        out_attempt(
+            Id::from(3),
+            V4_ADDR_2.into(),
+            CUSTOM_PORT,
+            ConnectionAttemptHttpVersions::H3,
+        ),
+        now,
+    );
+    he.expect(out_connection_attempt_delay(), now);
+
+    he.expect_connection_attempts(
+        [
+            out_attempt(
+                Id::from(4),
+                V6_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H2OrH1,
+            ),
+            out_attempt(
+                Id::from(5),
+                V4_ADDR.into(),
+                PORT,
+                ConnectionAttemptHttpVersions::H2OrH1,
+            ),
+        ],
+        &mut now,
+    );
+}
+
+/// An IP-literal origin combined with an alt-svc host that is a domain: the
+/// origin IP is attempted immediately while the alt-svc host is resolved in the
+/// background and attempted once its addresses arrive.
+#[test]
+fn ip_host_alt_svc_with_host() {
+    const ALT_HOST: &str = "alt.example.com";
+    let mut now = Instant::now();
+    let config = NetworkConfig {
+        alt_svc: vec![AltSvc {
+            host: Some(ALT_HOST.to_string()),
+            port: Some(CUSTOM_PORT),
+            http_version: HttpVersion::H3,
+        }],
+        ..NetworkConfig::default()
+    };
+    let mut he =
+        HappyEyeballs::new_with_network_config(&V4_ADDR.to_string(), PORT, config).unwrap();
+
+    // The origin IP is attempted right away (no DNS needed for it)...
+    he.expect(
+        out_attempt(
+            Id::from(0),
+            V4_ADDR.into(),
+            PORT,
+            ConnectionAttemptHttpVersions::H2OrH1,
+        ),
+        now,
+    );
+    // ...while the alt-svc host still needs to be resolved.
+    he.expect(
+        out_send_dns(Id::from(1), ALT_HOST, DnsRecordType::Aaaa),
+        now,
+    );
+    he.expect(out_send_dns(Id::from(2), ALT_HOST, DnsRecordType::A), now);
+    he.expect(out_connection_attempt_delay(), now);
+
+    he.input(
+        Input::DnsResult {
+            id: Id::from(1),
+            result: DnsResult::Aaaa(Ok(vec![V6_ADDR_2])),
+        },
+        now,
+    );
+    he.input(
+        Input::DnsResult {
+            id: Id::from(2),
+            result: DnsResult::A(Ok(vec![V4_ADDR_2])),
+        },
+        now,
+    );
+
+    he.expect_connection_attempts(
+        [
+            out_attempt(
+                Id::from(3),
+                V6_ADDR_2.into(),
+                CUSTOM_PORT,
+                ConnectionAttemptHttpVersions::H3,
+            ),
+            out_attempt(
+                Id::from(4),
+                V4_ADDR_2.into(),
+                CUSTOM_PORT,
+                ConnectionAttemptHttpVersions::H3,
             ),
         ],
         &mut now,


### PR DESCRIPTION
Until now an AltSvc with a host set was unsupported: a debug assertion guarded against it and only the http_version and port were honoured, against the origin's resolved addresses.

Per RFC 7838 an alt-svc entry advertises the origin's service at a host (and optionally port) over a given protocol. An entry without a host of its own is just the same thing defaulting to the origin host, so both kinds are now handled by one path: the entry's effective host is resolved via its own A/AAAA queries (or used directly when it is an IP literal) and attempted at the alt-svc port (defaulting to the origin port) over the alt-svc protocol. Hosts that name a domain other than the origin get their own A/AAAA queries; entries without a host reuse the origin's.

Alt-svc and the plain origin fallback are emitted as a single tier after the HTTPS-record endpoints, interleaved together by protocol and address family, and carry no ECH since an alt-svc target may differ from the origin. This also folds the previous IP-origin and domain-origin endpoint builders into one.